### PR TITLE
🛡️ Sentinel: [HIGH] Add CORS and TrustedHost middlewares

### DIFF
--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, Callable
 import uvicorn
 import pandas as pd
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel
 
 from confluent_kafka import Producer, Consumer, KafkaError, Message
@@ -29,6 +31,8 @@ DEFAULT_INPUT_TOPIC = os.getenv("DEFAULT_INPUT_TOPIC", "input_topic")
 DEFAULT_OUTPUT_TOPIC = os.getenv("DEFAULT_OUTPUT_TOPIC", "output_topic")
 DEFAULT_FASTAPI_HOST = os.getenv("DEFAULT_FASTAPI_HOST", "127.0.0.1")
 DEFAULT_FASTAPI_PORT = int(os.getenv("DEFAULT_FASTAPI_PORT", 8100))
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 LOGGING_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
 
@@ -41,6 +45,23 @@ app: FastAPI = FastAPI(
     title="Prediction Service API",
     description="A FastAPI service that integrates with Kafka for making predictions.",
     version="1.0.0",
+)
+
+# Security Middleware Configuration
+# If ALLOWED_ORIGINS contains *, allow_credentials must be False to prevent browser errors
+allow_credentials = "*" not in ALLOWED_ORIGINS
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=allow_credentials,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=ALLOWED_HOSTS,
 )
 
 

--- a/tests/controller/test_middleware.py
+++ b/tests/controller/test_middleware.py
@@ -1,0 +1,29 @@
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from regression_model_template.controller.kafka_app import app
+
+
+def test_middleware_configuration():
+    """Test that CORS and TrustedHost middlewares are configured."""
+    middlewares = [m.cls for m in app.user_middleware]
+
+    # Check for CORSMiddleware
+    assert CORSMiddleware in middlewares, "CORSMiddleware is missing"
+
+    # Check for TrustedHostMiddleware
+    assert TrustedHostMiddleware in middlewares, "TrustedHostMiddleware is missing"
+
+
+def test_cors_middleware_options():
+    """Test CORSMiddleware configuration details."""
+    cors_middleware = next((m for m in app.user_middleware if m.cls == CORSMiddleware), None)
+    assert cors_middleware is not None
+
+    # We can inspect the options passed to the middleware
+    # Note: In Starlette/FastAPI, middleware options are stored in .kwargs or .options
+    # For CORSMiddleware, we expect allow_origins, allow_credentials, etc.
+
+    options = cors_middleware.kwargs
+    assert "allow_origins" in options
+    assert "allow_methods" in options
+    assert "allow_headers" in options


### PR DESCRIPTION
This PR enhances the security of the FastAPI application by adding `CORSMiddleware` and `TrustedHostMiddleware`.

**Changes:**
- Imported `CORSMiddleware` and `TrustedHostMiddleware` in `src/regression_model_template/controller/kafka_app.py`.
- Added configuration constants `ALLOWED_ORIGINS` and `ALLOWED_HOSTS` defaulting to `*` (which can be overridden via environment variables).
- Added logic to set `allow_credentials=False` if `ALLOWED_ORIGINS` contains `*` to prevent browser errors and adhere to security best practices.
- Registered both middlewares in the FastAPI app.
- Added a new test file `tests/controller/test_middleware.py` to verify that the middlewares are correctly added and configured.

**Verification:**
- Ran `poetry run pytest tests/controller/test_middleware.py` (Passed).
- Ran full test suite `poetry run pytest` (Passed).
- Checked formatting with `poetry run invoke checks`.


---
*PR created automatically by Jules for task [7777084187091207911](https://jules.google.com/task/7777084187091207911) started by @lgcorzo*