### PR TITLE
🛡️ Sentinel: [HIGH] Add CORS and TrustedHost middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The application was catching exceptions in logic callbacks and Kafka consumers, then assigning the raw exception string to a JSON `error` field in the successful response object. This leaked internal details even when the HTTP status code was 200 OK or when processing asynchronously via Kafka.
 **Learning:** Checking for HTTP 500 handlers is not enough. Review application-level error handling where business logic manually constructs error objects.
 **Prevention:** Ensure that any `result["error"]` or similar fields populated in catch blocks use generic messages, while the real exception is logged server-side.
+
+## 2026-02-15 - Missing Security Middleware in FastAPI
+**Vulnerability:** The FastAPI application lacked `CORSMiddleware` and `TrustedHostMiddleware`, making it potentially vulnerable to Cross-Site Scripting (XSS) via loose CORS and Host Header attacks.
+**Learning:** Even if a project structure implies security (e.g., specific middleware files), the main application entry point (`kafka_app.py` in this case) must explicitly add these middlewares. Defaulting to secure-by-default or explicit configuration is crucial.
+**Prevention:** Always verify `app.add_middleware` calls in the application factory or main script. Use environment variables for `ALLOWED_ORIGINS` and `ALLOWED_HOSTS` to allow strict configuration in production while maintaining development ease.

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, Callable
 import uvicorn
 import pandas as pd
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel
 
 from confluent_kafka import Producer, Consumer, KafkaError, Message
@@ -29,6 +31,10 @@ DEFAULT_INPUT_TOPIC = os.getenv("DEFAULT_INPUT_TOPIC", "input_topic")
 DEFAULT_OUTPUT_TOPIC = os.getenv("DEFAULT_OUTPUT_TOPIC", "output_topic")
 DEFAULT_FASTAPI_HOST = os.getenv("DEFAULT_FASTAPI_HOST", "127.0.0.1")
 DEFAULT_FASTAPI_PORT = int(os.getenv("DEFAULT_FASTAPI_PORT", 8100))
+# Security Configuration
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
+
 LOGGING_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
 
@@ -41,6 +47,20 @@ app: FastAPI = FastAPI(
     title="Prediction Service API",
     description="A FastAPI service that integrates with Kafka for making predictions.",
     version="1.0.0",
+)
+
+# Add Middlewares
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=ALLOWED_HOSTS,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True if "*" not in ALLOWED_ORIGINS else False,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 

--- a/tests/controller/test_kafka_app_middleware.py
+++ b/tests/controller/test_kafka_app_middleware.py
@@ -1,0 +1,17 @@
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from regression_model_template.controller.kafka_app import app
+
+
+def test_middleware_presence():
+    """Test that security middlewares are present in the FastAPI app."""
+    middleware_types = [m.cls for m in app.user_middleware]
+
+    # Check for CORSMiddleware
+    has_cors = CORSMiddleware in middleware_types
+
+    # Check for TrustedHostMiddleware
+    has_trusted_host = TrustedHostMiddleware in middleware_types
+
+    assert has_cors, "CORSMiddleware is missing"
+    assert has_trusted_host, "TrustedHostMiddleware is missing"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add CORS and TrustedHost middleware

**Vulnerability:** The FastAPI application (`kafka_app.py`) was missing `CORSMiddleware` and `TrustedHostMiddleware`, making it susceptible to loose CORS policies and potentially Host Header attacks if deployed without an external gateway handling these.

**Impact:**
-   **CORS:** Malicious websites could potentially make requests to the API on behalf of users if not properly restricted.
-   **Host Header:** The application could be tricked into generating incorrect links or poisoning caches if the Host header is spoofed.

**Fix:**
-   Added `CORSMiddleware` and `TrustedHostMiddleware` to `kafka_app.py`.
-   Configured `ALLOWED_ORIGINS` and `ALLOWED_HOSTS` via environment variables (defaulting to `*` for backward compatibility/dev convenience, but allowing strict config in production).
-   Ensured `allow_credentials` is automatically disabled if `ALLOWED_ORIGINS` contains `*`.

**Verification:**
-   Added `tests/controller/test_kafka_app_middleware.py` which verifies the presence of these middlewares in the app stack.
-   Ran existing tests (`pytest tests/controller/`) to ensure no regressions.
-   Ran full check suite (`poetry run invoke checks`).

---
*PR created automatically by Jules for task [14499162341721191139](https://jules.google.com/task/14499162341721191139) started by @lgcorzo*