### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage in Application Logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Vulnerability:** The Kafka consumer was initializing a Pydantic model with default values and then assigning fields directly (e.g., `model = Model(); model.field = data`). This bypasses Pydantic validation because `validate_assignment` is `False` by default, allowing invalid or malicious data (like excessive rows causing DoS) to be processed.
 **Learning:** Pydantic models only validate arguments passed to `__init__` by default. Manual assignment after instantiation is unsafe for untrusted input.
 **Prevention:** Always instantiate Pydantic models with the data as keyword arguments (e.g., `model = Model(field=data)`) to ensure validation logic runs.
+
+## 2026-11-05 - Information Leakage in Application Logs
+
+**Vulnerability:** The application was logging full prediction input payloads and full prediction outputs at the `INFO` level. This risks exposing sensitive user data, PII, and internal prediction details into centralized, broad-access logging systems.
+**Learning:** Developers often log full request/response objects during development at `INFO` level and forget to downgrade them to `DEBUG` for production, leading to log-based data leakage and log denial-of-service.
+**Prevention:** In production, log full payloads only at `DEBUG` level. `INFO` level logs should be restricted to safe, aggregated metadata (e.g., "Received HTTP prediction request with X rows").

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -223,7 +223,12 @@ class FastAPIKafkaService:
             kafka_msg = json.loads(msg.value().decode("utf-8"))
             # Use constructor to ensure validation runs
             input_obj = PredictionRequest(input_data=kafka_msg["input_data"])
-            logger.info(f"kafka Received input  {kafka_msg}")
+            logger.debug(f"kafka Received input  {kafka_msg}")
+            try:
+                row_count = len(next(iter(kafka_msg["input_data"].values())))
+                logger.info(f"Received Kafka prediction request with {row_count} rows")
+            except Exception:
+                logger.info("Received Kafka prediction request (malformed data)")
             prediction_result = self.prediction_callback(input_obj).result
         except Exception as e:
             logger.exception(f"Error during prediction processing: {e}")
@@ -279,9 +284,14 @@ async def predict(request: PredictionRequest) -> PredictionResponse:  # Use glob
     """Endpoint for making predictions via HTTP."""
     global fastapi_kafka_service
     try:
-        logger.info(f"Received HTTP prediction request: {request}")
+        logger.debug(f"Received HTTP prediction request: {request}")
+        try:
+            row_count = len(next(iter(request.input_data.values())))
+            logger.info(f"Received HTTP prediction request with {row_count} rows")
+        except Exception:
+            logger.info("Received HTTP prediction request (malformed data)")
         prediction_result = fastapi_kafka_service.prediction_callback(request)
-        logger.info(f"HTTP prediction result: {prediction_result}")
+        logger.debug(f"HTTP prediction result: {prediction_result}")
         return prediction_result  # Use the global class
     except Exception:
         logger.exception("Error processing HTTP prediction request:")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was logging full prediction input payloads and full prediction outputs at the `INFO` level. This risks exposing sensitive user data, PII, and internal prediction details into centralized, broad-access logging systems.
🎯 Impact: Sensitive user data or intellectual property could be leaked to any developer with access to the central logging system, leading to privacy violations or data breaches.
🔧 Fix: Moved logging of raw user payloads and prediction responses from `INFO` to `DEBUG` level. Replaced them with safe `INFO` level summary logs that merely note the number of rows received.
✅ Verification: Ran `poetry run pytest tests/controller/` and verified that logs only include row counts at `INFO` level, and full payloads are isolated to `DEBUG` level.

---
*PR created automatically by Jules for task [8132319962266589314](https://jules.google.com/task/8132319962266589314) started by @lgcorzo*