### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage and Log DoS via Excessive Logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Vulnerability:** The Kafka consumer was initializing a Pydantic model with default values and then assigning fields directly (e.g., `model = Model(); model.field = data`). This bypasses Pydantic validation because `validate_assignment` is `False` by default, allowing invalid or malicious data (like excessive rows causing DoS) to be processed.
 **Learning:** Pydantic models only validate arguments passed to `__init__` by default. Manual assignment after instantiation is unsafe for untrusted input.
 **Prevention:** Always instantiate Pydantic models with the data as keyword arguments (e.g., `model = Model(field=data)`) to ensure validation logic runs.
+
+## 2026-03-07 - Information Leakage and Log DoS via Excessive Logging
+
+**Vulnerability:** The application was logging full raw input payloads (Kafka messages and HTTP requests) and responses at the `INFO` level. In a production environment, this could lead to Information Leakage (exposing sensitive PII/PHI or proprietary data in logs) and Log Denial of Service (filling up log storage with massive payloads).
+**Learning:** Developers often log full request/response payloads at `INFO` level for debugging during development, but forget to restrict this in production. High-volume or large-payload endpoints can quickly overwhelm logging infrastructure.
+**Prevention:** Log raw payloads only at `DEBUG` level. At `INFO` level, log only safe summaries, such as the row counts of the processed data. Ensure safe extraction logic (like using a `try...except` block) when calculating summaries from raw inputs to prevent malformed data from causing exceptions during logging.

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -223,7 +223,12 @@ class FastAPIKafkaService:
             kafka_msg = json.loads(msg.value().decode("utf-8"))
             # Use constructor to ensure validation runs
             input_obj = PredictionRequest(input_data=kafka_msg["input_data"])
-            logger.info(f"kafka Received input  {kafka_msg}")
+            logger.debug(f"kafka Received input  {kafka_msg}")
+            try:
+                row_count = len(next(iter(kafka_msg["input_data"].values())))
+                logger.info(f"Kafka Received input with {row_count} rows")
+            except Exception:
+                logger.info("Kafka Received input data")
             prediction_result = self.prediction_callback(input_obj).result
         except Exception as e:
             logger.exception(f"Error during prediction processing: {e}")
@@ -279,9 +284,19 @@ async def predict(request: PredictionRequest) -> PredictionResponse:  # Use glob
     """Endpoint for making predictions via HTTP."""
     global fastapi_kafka_service
     try:
-        logger.info(f"Received HTTP prediction request: {request}")
+        logger.debug(f"Received HTTP prediction request: {request}")
+        try:
+            row_count = len(next(iter(request.input_data.values())))
+            logger.info(f"Received HTTP prediction request with {row_count} rows")
+        except Exception:
+            logger.info("Received HTTP prediction request")
         prediction_result = fastapi_kafka_service.prediction_callback(request)
-        logger.info(f"HTTP prediction result: {prediction_result}")
+        logger.debug(f"HTTP prediction result: {prediction_result}")
+        try:
+            inference_len = len(prediction_result.result.get("inference", []))
+            logger.info(f"HTTP prediction result generated {inference_len} predictions")
+        except Exception:
+            logger.info("HTTP prediction result generated")
         return prediction_result  # Use the global class
     except Exception:
         logger.exception("Error processing HTTP prediction request:")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The application was logging full raw input payloads (Kafka messages and HTTP requests) and responses at the `INFO` level. In a production environment, this could lead to Information Leakage (exposing sensitive PII/PHI or proprietary data in logs) and Log Denial of Service (filling up log storage with massive payloads).

🎯 **Impact:** Exposing sensitive user data in application logs violates privacy compliance (e.g. GDPR/CCPA) and puts user data at risk in the event of unauthorized log access. Massive payloads from high volume endpoints could also overwhelm the logging infrastructure.

🔧 **Fix:** Changed raw payload logging (`kafka_msg`, `request`, `prediction_result`) to `DEBUG` level. At `INFO` level, added a safe extraction (`try...except`) to log only safe summaries, such as the row count of the payload, preventing information leakage while retaining operational visibility.

✅ **Verification:**
1. Ran all tests (`poetry run invoke checks` & `pytest`).
2. Confirmed via logs that `INFO` now contains summaries while `DEBUG` retains full tracing.
3. Created Sentinel journal entry in `.jules/sentinel.md` outlining the findings.

---
*PR created automatically by Jules for task [1097663321870250444](https://jules.google.com/task/1097663321870250444) started by @lgcorzo*