### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage and Log DoS via INFO Level Input Payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Vulnerability:** The Kafka consumer was initializing a Pydantic model with default values and then assigning fields directly (e.g., `model = Model(); model.field = data`). This bypasses Pydantic validation because `validate_assignment` is `False` by default, allowing invalid or malicious data (like excessive rows causing DoS) to be processed.
 **Learning:** Pydantic models only validate arguments passed to `__init__` by default. Manual assignment after instantiation is unsafe for untrusted input.
 **Prevention:** Always instantiate Pydantic models with the data as keyword arguments (e.g., `model = Model(field=data)`) to ensure validation logic runs.
+
+## 2026-03-09 - Information Leakage and Log DoS via INFO Level Input Payloads
+
+**Vulnerability:** The application was logging the full incoming prediction requests (both via Kafka and HTTP) at the `INFO` level. Given the potential size of these payloads (up to 10,000 rows), this could lead to log Denial of Service (filling up disk space quickly) and leak sensitive input data into production logs.
+**Learning:** Production logs should generally not contain full raw user inputs, especially for data processing APIs where inputs can be large or sensitive. Verbose logging should be restricted to `DEBUG` levels.
+**Prevention:** Log full input payloads only at the `DEBUG` level. At `INFO` level, log safe summaries (like row counts or metadata) wrapped in `try...except` blocks to prevent malformed data from crashing the application.

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -223,7 +223,14 @@ class FastAPIKafkaService:
             kafka_msg = json.loads(msg.value().decode("utf-8"))
             # Use constructor to ensure validation runs
             input_obj = PredictionRequest(input_data=kafka_msg["input_data"])
-            logger.info(f"kafka Received input  {kafka_msg}")
+            logger.debug(f"kafka Received input  {kafka_msg}")
+
+            try:
+                row_count = len(next(iter(kafka_msg.get("input_data", {}).values())))
+                logger.info(f"Kafka received input with {row_count} rows")
+            except Exception:
+                logger.info("Kafka received input with unknown number of rows")
+
             prediction_result = self.prediction_callback(input_obj).result
         except Exception as e:
             logger.exception(f"Error during prediction processing: {e}")
@@ -279,9 +286,16 @@ async def predict(request: PredictionRequest) -> PredictionResponse:  # Use glob
     """Endpoint for making predictions via HTTP."""
     global fastapi_kafka_service
     try:
-        logger.info(f"Received HTTP prediction request: {request}")
+        logger.debug(f"Received HTTP prediction request: {request}")
+
+        try:
+            row_count = len(next(iter(request.input_data.values())))
+            logger.info(f"HTTP received input with {row_count} rows")
+        except Exception:
+            logger.info("HTTP received input with unknown number of rows")
+
         prediction_result = fastapi_kafka_service.prediction_callback(request)
-        logger.info(f"HTTP prediction result: {prediction_result}")
+        logger.debug(f"HTTP prediction result: {prediction_result}")
         return prediction_result  # Use the global class
     except Exception:
         logger.exception("Error processing HTTP prediction request:")

--- a/tests/controller/test_kafka_app.py
+++ b/tests/controller/test_kafka_app.py
@@ -245,9 +245,9 @@ def test_process_message_json_decode_error(mock_json_loads, mock_kafka_service):
 
     service.producer = MagicMock()
     service.consumer = MagicMock()
-    with patch("regression_model_template.controller.kafka_app.logger.error") as mock_logger_error:
+    with patch("regression_model_template.controller.kafka_app.logger.exception") as mock_logger_exception:
         service._process_message(msg)
-        mock_logger_error.assert_called()
+        mock_logger_exception.assert_called()
     service.prediction_callback.assert_not_called()
     service.producer.produce.assert_called_once()
 
@@ -305,11 +305,11 @@ async def test_predict_endpoint():
         mock_fastapi_kafka_service.prediction_callback.return_value = PredictionResponse(
             result={"inference": [1.0], "quality": 1.0, "error": None}
         )
-        with patch("regression_model_template.controller.kafka_app.logger.info") as mock_logger_info:
+        with patch("regression_model_template.controller.kafka_app.logger.debug") as mock_logger_debug:
             request = PredictionRequest()
             response = await predict(request)
             assert response.result["inference"] == [1.0]
-            mock_logger_info.assert_called()
+            mock_logger_debug.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application logs the full incoming prediction requests (both via Kafka and HTTP) at the `INFO` level. Given the potential size of these payloads (up to 10,000 rows), this could lead to log Denial of Service (filling up disk space quickly) and leak sensitive input data into production logs.
🎯 Impact: Could cause application unresponsiveness due to exhausted disk space, or sensitive inputs becoming accessible through unauthorized log parsing or aggregation.
🔧 Fix: Changed logging of the full payload to `DEBUG` level and introduced a safe try...except wrapper to log only the number of received rows at the `INFO` level.
✅ Verification: Ran `pytest` locally on `tests/controller/test_kafka_app.py` and ensure the logs assert the `logger.debug` call instead of `logger.info` for the raw payload. Checked existing tests logic. Tested using `invoke checks`. Added journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5846073643383684302](https://jules.google.com/task/5846073643383684302) started by @lgcorzo*