### PR TITLE
🛡️ Sentinel: [security improvement] Add Security HTTP Headers Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,9 @@
 **Learning:** Production logs should generally not contain full raw user inputs, especially for data processing APIs where inputs can be large or sensitive. Verbose logging should be restricted to `DEBUG` levels.
 **Prevention:** Log complete input payloads at `DEBUG` level only. Use `INFO` level logging to output safe, summarized information (like row and column counts) while ensuring extraction of summaries is wrapped in `try...except` to prevent application crashes from malformed data.
 
+
+## 2026-10-24 - Missing Security Headers
+
+**Vulnerability:** The FastAPI application was missing basic security HTTP headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`), leaving it vulnerable to MIME-type sniffing, Clickjacking, and Man-in-the-Middle attacks.
+**Learning:** Default FastAPI configurations do not automatically set security headers. Explicit middleware is needed to inject these headers into all HTTP responses.
+**Prevention:** Always add a custom middleware or use a specialized library to ensure all incoming responses get secure default headers (`nosniff`, `DENY`, HSTS).

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict
 import pandas as pd
 import uvicorn
 from confluent_kafka import Consumer, KafkaError, Message, Producer
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel, field_validator
@@ -59,6 +59,16 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next: Any) -> Any:
+    """Middleware to add security headers to HTTP responses."""
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    return response
 
 
 # Data Models


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: The FastAPI application was missing basic security HTTP headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`), leaving it vulnerable to MIME-type sniffing, Clickjacking, and Man-in-the-Middle attacks.
🎯 Impact: Prevents MIME-type sniffing, clickjacking, and enforces secure connections.
🔧 Fix: Added a custom HTTP middleware `add_security_headers` to automatically inject `nosniff`, `DENY`, and HSTS headers on all responses.
✅ Verification: Ran `poetry run pytest` to verify the application functionality remains intact with the new middleware. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6844993888041199077](https://jules.google.com/task/6844993888041199077) started by @lgcorzo*