### PR TITLE
🛡️ Sentinel: [HIGH] Add sliding window rate limiting to /predict API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,9 @@
 **Vulnerability:** The `_consume_messages` method contained a hardcoded `time.sleep(0.1)` inside the main `while` loop, creating an artificial bottleneck. This ignores the native blocking properties of `consumer.poll()` and needlessly limits message throughput, causing latency spikes and increasing the risk of Denial of Service (DoS) in high-volume environments.
 **Learning:** Manual thread sleeping is rarely necessary when a library exposes built-in waiting/polling timeouts (like `poll(1.0)`). Stacking custom `sleep()` logic on top of native polling leads to poor application performance.
 **Prevention:** Rely entirely on the consumer's `poll(timeout)` parameter to block while waiting for new messages efficiently. Avoid using arbitrary `time.sleep()` statements inside event loops or message-consuming pipelines unless explicitly needed for exponential backoff during error handling.
+
+## 2026-11-20 - Missing Rate Limiting on Prediction Endpoint
+
+**Vulnerability:** The HTTP `/predict` endpoint lacked any form of rate limiting, leaving it completely exposed to Denial of Service (DoS) attacks and brute-force abuse.
+**Learning:** Any publicly exposed computationally intensive endpoint, such as one handling machine learning inference, must have basic rate limiting to prevent both intentional algorithmic DoS and accidental request floods from overwhelming the server.
+**Prevention:** Implement an in-memory sliding window rate limiter backed by an `OrderedDict` with a maximum IP tracking capacity (e.g., `MAX_TRACKED_IPS = 10000`). This ensures O(1) eviction of the oldest tracked IPs, preventing memory leaks while reliably enforcing rate limits per client IP.

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -7,6 +7,7 @@ import signal
 import threading
 import time
 import typing as T
+from collections import OrderedDict
 from typing import Any, Callable, Dict
 
 import pandas as pd
@@ -33,6 +34,9 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
 LOGGING_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 MAX_INPUT_ROWS = 10000
+RATE_LIMIT_WINDOW = 60
+MAX_REQUESTS_PER_WINDOW = 100
+MAX_TRACKED_IPS = 10000
 
 # Security Configuration
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
@@ -284,8 +288,62 @@ class FastAPIKafkaService:
         logger.info("Service stopped.")
 
 
+class IPRateLimiter:
+    """In-memory sliding window rate limiter backed by an OrderedDict to track IP request counts."""
+
+    def __init__(
+        self,
+        max_requests: int = MAX_REQUESTS_PER_WINDOW,
+        window_size: int = RATE_LIMIT_WINDOW,
+        max_tracked_ips: int = MAX_TRACKED_IPS,
+    ):
+        self.max_requests = max_requests
+        self.window_size = window_size
+        self.max_tracked_ips = max_tracked_ips
+        self.tracked_ips: OrderedDict[str, list[float]] = OrderedDict()
+        self.lock = threading.Lock()
+
+    def is_rate_limited(self, ip: str) -> bool:
+        """Check if the IP has exceeded the rate limit."""
+        current_time = time.time()
+
+        with self.lock:
+            # Get or create the request list for this IP
+            if ip not in self.tracked_ips:
+                # If we've reached the max tracked IPs, evict the oldest (FIFO)
+                if len(self.tracked_ips) >= self.max_tracked_ips:
+                    self.tracked_ips.popitem(last=False)
+                self.tracked_ips[ip] = []
+
+            # Move the IP to the end (most recently used)
+            self.tracked_ips.move_to_end(ip)
+
+            # Filter out requests older than the window
+            requests = self.tracked_ips[ip]
+            window_start = current_time - self.window_size
+
+            # Find the index of the first request within the window
+            idx = 0
+            for req_time in requests:
+                if req_time >= window_start:
+                    break
+                idx += 1
+
+            # Keep only requests within the window
+            requests = requests[idx:]
+            self.tracked_ips[ip] = requests
+
+            if len(requests) >= self.max_requests:
+                return True
+
+            # Add the current request
+            self.tracked_ips[ip].append(current_time)
+            return False
+
+
 # Global Service Instance
 fastapi_kafka_service: "FastAPIKafkaService" = T.cast("FastAPIKafkaService", None)
+rate_limiter = IPRateLimiter()
 
 
 # FastAPI Endpoints
@@ -296,9 +354,16 @@ fastapi_kafka_service: "FastAPIKafkaService" = T.cast("FastAPIKafkaService", Non
     description="This endpoint allows you to submit data for a prediction.",
     tags=["Prediction"],
 )
-async def predict(request: PredictionRequest) -> PredictionResponse:  # Use global var
+async def predict(request: PredictionRequest, http_request: Request) -> PredictionResponse:  # Use global var
     """Endpoint for making predictions via HTTP."""
     global fastapi_kafka_service
+
+    if http_request and http_request.client:
+        client_ip = http_request.client.host
+        if rate_limiter.is_rate_limited(client_ip):
+            logger.warning(f"Rate limit exceeded for IP: {client_ip}")
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+
     try:
         logger.debug(f"Received HTTP prediction request: {request}")
         try:

--- a/tests/controller/test_kafka_app.py
+++ b/tests/controller/test_kafka_app.py
@@ -307,7 +307,9 @@ async def test_predict_endpoint():
         )
         with patch("regression_model_template.controller.kafka_app.logger.debug") as mock_logger_debug:
             request = PredictionRequest()
-            response = await predict(request)
+            mock_request = MagicMock()
+            mock_request.client.host = "127.0.0.1"
+            response = await predict(request, http_request=mock_request)
             assert response.result["inference"] == [1.0]
             mock_logger_debug.assert_called()
 
@@ -317,7 +319,9 @@ async def test_predict_endpoint_exception():
     with patch("regression_model_template.controller.kafka_app.fastapi_kafka_service") as mock_fastapi_kafka_service:
         mock_fastapi_kafka_service.prediction_callback.side_effect = Exception("Test Exception")
         with pytest.raises(HTTPException):
-            await predict(PredictionRequest())
+            mock_request = MagicMock()
+            mock_request.client.host = "127.0.0.1"
+            await predict(PredictionRequest(), http_request=mock_request)
 
 
 @pytest.mark.asyncio

--- a/tests/controller/test_kafka_app_logging.py
+++ b/tests/controller/test_kafka_app_logging.py
@@ -52,7 +52,9 @@ async def test_predict_endpoint_logging(mock_logger):
         mock_fastapi_kafka_service.prediction_callback.return_value = mock_response
 
         request = PredictionRequest()
-        response = await predict(request)
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        response = await predict(request, http_request=mock_request)
 
         # Verify the response is returned
         assert response == mock_response

--- a/tests/controller/test_kafka_app_security.py
+++ b/tests/controller/test_kafka_app_security.py
@@ -44,7 +44,9 @@ def test_predict_endpoint_exception_leak():
 
             # Expect an HTTPException
             with pytest.raises(HTTPException) as excinfo:
-                await predict(PredictionRequest())
+                mock_request = MagicMock()
+                mock_request.client.host = "127.0.0.1"
+                await predict(PredictionRequest(), http_request=mock_request)
 
             # Verify that the sensitive message is leaked in the detail
             assert excinfo.value.status_code == 500

--- a/tests/controller/test_log_leakage.py
+++ b/tests/controller/test_log_leakage.py
@@ -66,7 +66,9 @@ async def test_predict_log_leakage(caplog):
         caplog.set_level(logging.INFO)
 
         # Call the endpoint
-        await predict(request)
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        await predict(request, http_request=mock_request)
 
         # Check logs for leakage
         # If the sensitive value appears in the INFO logs, this assertion will fail

--- a/tests/controller/test_rate_limiter.py
+++ b/tests/controller/test_rate_limiter.py
@@ -1,0 +1,78 @@
+import time
+from unittest.mock import patch
+from regression_model_template.controller.kafka_app import IPRateLimiter
+
+
+def test_rate_limiter_allows_requests():
+    """Test that the rate limiter allows normal requests within limit."""
+    limiter = IPRateLimiter(max_requests=5, window_size=60)
+
+    # Send 5 requests, all should be allowed
+    for _ in range(5):
+        assert limiter.is_rate_limited("192.168.1.1") is False
+
+
+def test_rate_limiter_blocks_excessive_requests():
+    """Test that the rate limiter blocks requests exceeding the limit."""
+    limiter = IPRateLimiter(max_requests=5, window_size=60)
+
+    # Send 5 requests, all should be allowed
+    for _ in range(5):
+        assert limiter.is_rate_limited("192.168.1.1") is False
+
+    # The 6th request should be blocked
+    assert limiter.is_rate_limited("192.168.1.1") is True
+
+
+def test_rate_limiter_window_expiry():
+    """Test that the rate limiter allows requests after the window expires."""
+    limiter = IPRateLimiter(max_requests=2, window_size=1)
+
+    # Send 2 requests
+    assert limiter.is_rate_limited("192.168.1.2") is False
+    assert limiter.is_rate_limited("192.168.1.2") is False
+
+    # The 3rd request is blocked
+    assert limiter.is_rate_limited("192.168.1.2") is True
+
+    # Wait for the window to expire
+    with patch("time.time", return_value=time.time() + 2):
+        # The request should be allowed again
+        assert limiter.is_rate_limited("192.168.1.2") is False
+
+
+def test_rate_limiter_evicts_oldest_ip():
+    """Test that the rate limiter evicts the oldest IP when tracking capacity is reached."""
+    # Create limiter with capacity of 3 IPs
+    limiter = IPRateLimiter(max_tracked_ips=3)
+
+    # Track 3 IPs
+    limiter.is_rate_limited("10.0.0.1")
+    limiter.is_rate_limited("10.0.0.2")
+    limiter.is_rate_limited("10.0.0.3")
+
+    assert "10.0.0.1" in limiter.tracked_ips
+    assert "10.0.0.2" in limiter.tracked_ips
+    assert "10.0.0.3" in limiter.tracked_ips
+    assert len(limiter.tracked_ips) == 3
+
+    # Adding a 4th IP should evict the oldest one ("10.0.0.1")
+    limiter.is_rate_limited("10.0.0.4")
+
+    assert "10.0.0.1" not in limiter.tracked_ips
+    assert "10.0.0.2" in limiter.tracked_ips
+    assert "10.0.0.3" in limiter.tracked_ips
+    assert "10.0.0.4" in limiter.tracked_ips
+    assert len(limiter.tracked_ips) == 3
+
+    # Updating an existing IP should move it to the end (most recently used)
+    limiter.is_rate_limited("10.0.0.2")
+
+    # Now adding another IP should evict "10.0.0.3" since "10.0.0.2" was just accessed
+    limiter.is_rate_limited("10.0.0.5")
+
+    assert "10.0.0.3" not in limiter.tracked_ips
+    assert "10.0.0.2" in limiter.tracked_ips
+    assert "10.0.0.4" in limiter.tracked_ips
+    assert "10.0.0.5" in limiter.tracked_ips
+    assert len(limiter.tracked_ips) == 3


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The HTTP `/predict` endpoint lacked basic rate limiting, making it vulnerable to brute-force and Denial of Service (DoS) attacks.
🎯 **Impact:** An attacker could exhaust server resources by sending rapid, continuous requests to the CPU/memory-bound ML inference endpoint. Over time, without an eviction policy, tracking IP bounds could also lead to a memory leak.
🔧 **Fix:** Implemented an `IPRateLimiter` using a sliding window algorithm and an `OrderedDict` with a `MAX_TRACKED_IPS` cap. This guarantees O(1) LRU eviction to constrain memory usage while actively rejecting requests from abusive IPs.
✅ **Verification:** Handled by the newly added unit test `tests/controller/test_rate_limiter.py` and updated controller endpoint tests.

---
*PR created automatically by Jules for task [6569490361126087925](https://jules.google.com/task/6569490361126087925) started by @lgcorzo*