### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage in Validation Errors

### DIFF
--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -14,6 +14,9 @@ import pandas as pd
 import uvicorn
 from confluent_kafka import Consumer, KafkaError, Message, Producer
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -80,6 +83,17 @@ async def add_security_headers(request: Request, call_next: Any) -> Any:
     )
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Sanitize validation errors to prevent echoing sensitive input data."""
+    sanitized_errors = []
+    for error in exc.errors():
+        sanitized_error = {k: v for k, v in error.items() if k != "input"}
+        sanitized_errors.append(sanitized_error)
+    logger.debug(f"Validation error: {sanitized_errors}")
+    return JSONResponse(status_code=422, content={"detail": jsonable_encoder(sanitized_errors)})
 
 
 class RateLimiter:


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Information Leakage via FastAPI/Pydantic validation errors. By default, FastAPI's `RequestValidationError` handler returns the raw payload that caused the validation failure in the `input` field of the `422` response body.
🎯 **Impact**: If a user submits sensitive data (like a password in an extra field, or large payloads) and it fails validation, that data is echoed back to the client unencrypted in the response. It also introduces a potential Log/Bandwidth DoS if large payloads fail validation.
🔧 **Fix**: Added a custom `@app.exception_handler(RequestValidationError)` that intercepts the error and strips the `input` key from the `exc.errors()` list before returning it in a `JSONResponse` using `jsonable_encoder`. It also ensures the logged version at DEBUG level is the sanitized version.
✅ **Verification**: Run `poetry run pytest tests/controller`. Manually tested by sending invalid payloads with extra/malformed fields; confirmed the `input` key is completely absent from the returned JSON response.

---
*PR created automatically by Jules for task [14441895184424295409](https://jules.google.com/task/14441895184424295409) started by @lgcorzo*