### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,8 @@ on:
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
+permissions:
+  contents: read
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lgcorzo/mlops-python-package/security/code-scanning/6](https://github.com/lgcorzo/mlops-python-package/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions directly under `concurrency` (before `jobs`) with:

- `contents: read`

This preserves existing functionality for a PR checks workflow that only checks out code and runs validations, while making token scope explicit and compliant with CodeQL guidance. No imports, methods, or dependencies are needed; only `.github/workflows/check.yml` is edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
