### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ concurrency:
   group: publish-workflow
 jobs:
   pages:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/lgcorzo/mlops-python-package/security/code-scanning/5](https://github.com/lgcorzo/mlops-python-package/security/code-scanning/5)

Add an explicit `permissions` block to the `pages` job so the token scopes are minimal and explicit for that job.  
Best single fix without changing behavior: define only the permissions needed by `pages`:

- `contents: read` (needed by `actions/checkout`)
- `pages: write` (needed by `github-pages-deploy-action` to publish)
- `id-token: write` (commonly required for pages-related deploy/auth flows)

This keeps existing functionality while enforcing least privilege and resolving the CodeQL finding at the highlighted job.  
Edit file: `.github/workflows/publish.yml` in the `jobs.pages` section, inserting `permissions:` under `pages:` and before `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
