### PR TITLE
Update Wiki to be Fully OKF Standard

### DIFF
--- a/wiki/Base_stories.md
+++ b/wiki/Base_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "High-Level Project Jobs User Story"
+description: "Manage the execution context for high-level project jobs with integrated services."
+tags:
+  - base
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [High-Level Project Jobs](backlog_mlops_regresion) : Manage the execution context for high-level project jobs with integrated services.
 
 - [US High-Level Project Jobs : Manage the execution context for high-level project jobs with integrated services.](#us-high-level-project-jobs--manage-the-execution-context-for-high-level-project-jobs-with-integrated-services)

--- a/wiki/Configs_stories.md
+++ b/wiki/Configs_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Configs User Story"
+description: "Parse, Merge, and Convert Configuration Objects"
+tags:
+  - configs
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Configs](backlog_mlops_regresion) : Parse, Merge, and Convert Configuration Objects
 
 - [US Configs : Parse, Merge, and Convert Configuration Objects](#us-configs--parse-merge-and-convert-configuration-objects)

--- a/wiki/Datasets_stories.md
+++ b/wiki/Datasets_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Datasetes User Story"
+description: "Handle loading, preprocessing, and managing data sets for training, evaluation, and inference."
+tags:
+  - datasets
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Datasetes](backlog_mlops_regresion) :  Handle loading, preprocessing, and managing data sets for training, evaluation, and inference.
 
 - [US Datasetes :  Handle loading, preprocessing, and managing data sets for training, evaluation, and inference.](#us-datasetes---handle-loading-preprocessing-and-managing-data-sets-for-training-evaluation-and-inference)

--- a/wiki/Evaluations_stories.md
+++ b/wiki/Evaluations_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Evaluations Job User Story"
+description: "Evaluate a registered model version against a dataset."
+tags:
+  - evaluations
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Evaluations Job](backlog_mlops_regresion) : Evaluate a registered model version against a dataset.
 
 - [US Model Evaluation Job : Define a job for evaluating registered models with given datasets.](#us-model-evaluation-job--define-a-job-for-evaluating-registered-models-with-given-datasets)

--- a/wiki/Explanations_stories.md
+++ b/wiki/Explanations_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Explanations Job User Story"
+description: "Explain predictions for a registered model version and dataset. structure and decisions."
+tags:
+  - explanations
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Explanations Job](backlog_mlops_regresion) : Explain predictions for a registered model version and dataset. structure and decisions.
 
 - [US Model Explanations Job : Define a job for explaining the model structure and decisions.](#us-model-explanations-job--define-a-job-for-explaining-the-model-structure-and-decisions)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,3 +1,14 @@
+---
+type: Guide
+title: "MLOps Python Package Wiki Home"
+description: "Welcome and quick start guide for the MLOps Python Package project."
+tags:
+  - home
+  - guide
+  - documentation
+  - mlops
+timestamp: "2026-04-18T12:00:00Z"
+---
 # Welcome to the MLOps Python Package Wiki 🚀
 
 This wiki contains the complete documentation for the MLOps Python Package project, including feature stories, architectural overviews, and implementation details.
@@ -8,9 +19,175 @@ This wiki contains the complete documentation for the MLOps Python Package proje
 *   **[Models & Data](Models_stories)**: Explore how models, datasets, and schemas are defined and managed.
 *   **[Lifecycle](Trainning_stories)**: Detailed guides on Training, Tuning, Evaluation, and Promotion.
 
-## 🏗️ Project Architecture
+---
 
-The project follows a modular design focused on scalability and reproducibility in MLOps workflows. You can find detailed descriptions of each component in the sidebar.
+## 🏗️ System Architecture & Modularity
+
+The project adheres to a clean, highly modular architecture designed to support scalable, robust, and reproducible machine learning operations (MLOps). The design separates core mathematical and domain-specific rules from input/output mechanics, background workflows, API controllers, and utility toolings.
+
+### Package Structures & Component Relationships
+
+1. **`core/`**: The Core Domain Layer
+   - **Metrics (`metrics.py`)**: Abstract base class `Metric` and concrete scikit-learn wrappers (e.g., `SklearnMetric`) to standardize prediction evaluations.
+   - **Models (`models.py`)**: Defines the unified model contract `Model` (using Pydantic validation) and baseline concrete model implementations (e.g., `BaselineSklearnModel` utilizing scikit-learn random forests).
+   - **Schemas (`schemas.py`)**: Enforces input, target, output, feature importance, and SHAP value structures using Pandera and Pydantic v2.
+
+2. **`io/`**: The Input/Output Integration Layer
+   - **Configs (`configs.py`)**: Standardizes config schemas and OmegaConf YAML loaders.
+   - **Datasets (`datasets.py`)**: Standardizes file and cloud-based read/write behaviors via abstract `Reader` / `Writer` and concrete `ParquetReader` / `ParquetWriter` implementations.
+   - **OSVariables (`osvariables.py`)**: Implements application-wide settings and configuration schemas with dotenv environment injection via Pydantic settings.
+   - **Registries (`registries.py`)**: Interacts with artifact stores such as local files or MLflow model storage.
+   - **Services (`services.py`)**: Manages the life cycle of runtime platform services like logging, alerting, and MLflow tracking.
+
+3. **`jobs/`**: Orchestration and Workflows (The Lifecycle Stage Layer)
+   - **Base (`base.py`)**: Orchestrates the setup, validation, execution, and teardown lifecycle of distinct operational pipelines.
+   - **Specific Workflows**: Training (`training.py`), Tuning (`tuning.py`), Evaluations (`evaluations.py`), Explanations (`explanations.py`), Inference (`inference.py`), Promotion (`promotion.py`).
+
+4. **`utils/`**: Shared Auxiliary Components
+   - Submodules for searchers (hyperparameter search), signers (model signing/provenance check), and splitters (reproducible cross-validation splitters).
+
+5. **`controller/`**: Integration and Streaming Endpoints
+   - **Kafka App (`kafka_app.py`)**: Exposes FastAPI endpoints and Kafka consumers (via `confluent_kafka`) for low-latency batch and streaming inference.
 
 ---
-*For technical details on individual modules, please refer to the [Sidebar](_Sidebar).*
+
+## 🎨 Architectural Design Patterns in Action
+
+To ensure decoupling and ease of swapability, several enterprise software patterns are instantiated directly inside the codebase:
+
+### 1. Strategy Pattern
+The Strategy pattern defines a family of algorithms, encapsulates each one, and makes them interchangeable.
+- **Interchangeable Models**: Any class subclassing the abstract `Model` can be fit and evaluated identically. The client code in jobs/training or jobs/inference doesn't care whether the model is a Scikit-Learn Random Forest or a deep learning neural net.
+- **Interchangeable Readers & Writers**: Reading parquet or CSV files uses the same `Reader` strategy.
+- **Hyperparameter Searchers**: The training job employs a `Searcher` strategy (e.g., Grid Search, Random Search, or Bayesian Optimization) to find the best configuration.
+
+### 2. Template Method Pattern
+The Template Method pattern defines the skeleton of an algorithm in an operation, deferring some steps to subclasses.
+- **Abstract Job Execution**: The `Job` class (in `jobs/base.py`) uses a context manager (`__enter__` and `__exit__`) to handle environment preparation and logging boilerplate, whereas subclasses only have to implement the customized `.run()` step.
+
+### 3. Composition over Inheritance
+- **Service Composition**: The `Job` class composes services (`LoggerService`, `AlertsService`, `MlflowService`) as internal attributes rather than inheriting from them, making it easy to mock, swap, or configure services individually.
+
+---
+
+## ⚡ Context Manager Pattern
+
+Python's Context Manager protocol (`__enter__` and `__exit__`) is heavily leveraged in the `Job` class to guarantee safety, resource cleanup, and consistent state transitions.
+
+### Boilerplate Reduction & Exception Safety
+The `Job` class orchestrates several external systems:
+1. **Logging**: Initialized immediately when entering the context.
+2. **Alerts**: Hooked to external alerting layers to notify teams of run statuses.
+3. **MLflow Tracking**: Establishes or restores tracking sessions and metrics pipelines.
+
+Using `with JobSubclass() as job:` ensures that even if a model explodes during fitting, the `__exit__` block executes to gracefully clean up and flush MLflow metrics, close alerting channels, and restore logger state before propagating the error upwards.
+
+### Code Example: Context Manager implementation in `Job`
+
+```python
+class Job(abc.ABC, pdt.BaseModel, strict=True, frozen=True, extra="forbid"):
+    KIND: str
+    logger_service: services.LoggerService = services.LoggerService()
+    alerts_service: services.AlertsService = services.AlertsService()
+    mlflow_service: services.MlflowService = services.MlflowService()
+
+    def __enter__(self) -> T.Self:
+        # 1. Setup Logging
+        self.logger_service.start()
+        logger = self.logger_service.logger()
+        logger.debug("[START] Logger service: {}", self.logger_service)
+
+        # 2. Setup Alerts and MLflow Tracking
+        self.alerts_service.start()
+        self.mlflow_service.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: T.Type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TS.TracebackType | None,
+    ) -> T.Literal[False]:
+        # Guarantees teardown execution order (LIFO-like logic)
+        logger = self.logger_service.logger()
+        self.mlflow_service.stop()
+        self.alerts_service.stop()
+        self.logger_service.stop()
+        return False  # Propagates any raised exceptions upwards
+```
+
+---
+
+## 🏷️ The `KIND` Parameter: Static & Polymorphic Discriminators
+
+The codebase uses a class constant named `KIND` on abstract bases (`Model`, `Reader`, `Writer`, `Job`, etc.) and sets it to specific string literals in concrete implementations.
+
+### Why `KIND` is Used:
+1. **Serialization and Deserialization (Pydantic Discriminator)**:
+   When reading a complex YAML/JSON configuration, Pydantic needs to determine which subclass of a model or reader to instantiate. By specifying `KIND: T.Literal["ParquetReader"] = "ParquetReader"`, Pydantic can automatically dispatch deserialization to the correct class.
+2. **Backwards Compatibility & Configuration Swapping**:
+   Configurations specify component kinds by string names, enabling run-time polymorphic dynamic swapping.
+
+### Code Example: Discriminator pattern inside `Model` and Subclasses
+
+```python
+# Base Model (src/regression_model_template/core/models.py)
+class Model(abc.ABC, pdt.BaseModel, strict=True, frozen=False, extra="forbid"):
+    KIND: str  # Abstract identifier
+
+# Concrete Model
+class BaselineSklearnModel(Model):
+    # Static Literal mapping acting as the discriminator
+    KIND: T.Literal["BaselineSklearnModel"] = "BaselineSklearnModel"
+    max_depth: int = 20
+    n_estimators: int = 200
+```
+
+---
+
+## 🧬 Inheritance and Polymorphism
+
+By inheriting from core base classes and defining polymorphic interfaces, the system achieves standard OOP benefits: high extensibility, code reuse, and clean contracts.
+
+### Example in `Reader` and `ParquetReader`
+
+```python
+# Abstract Base Class defining the contract (Polymorphism)
+class Reader(abc.ABC, pdt.BaseModel):
+    KIND: str
+    limit: int | None = None
+
+    @abc.abstractmethod
+    def read(self) -> pd.DataFrame:
+        """Abstract method to read data."""
+
+# Concrete realization of the contract (Inheritance)
+class ParquetReader(Reader):
+    KIND: T.Literal["ParquetReader"] = "ParquetReader"
+    path: str
+
+    def read(self) -> pd.DataFrame:
+        # Polymorphic implementation specific to Parquet files
+        if self.limit:
+            import pyarrow.dataset as ds
+            return ds.dataset(self.path).head(self.limit).to_pandas()
+        return pd.read_parquet(self.path)
+```
+
+---
+
+## 🛠️ Software Programming Methodologies
+
+The architecture and developer patterns follow precise modern software paradigms:
+
+### 1. Object-Oriented Programming (OOP)
+Fully utilizes encapsulation (prefixing private attributes with `_` to shield internal scikit-learn transformers), abstraction (`abc.ABC`), polymorphism, and inheritance to model domain elements cleanly.
+
+### 2. Test-Driven Development (TDD)
+Each module corresponds directly to rigorous unit and integration tests located under `tests/` (e.g., `test_models.py`, `test_datasets.py`, `test_base.py`). System behaviors are proven correct before deployment, preventing regressions.
+
+### 3. Clean Architecture (Separation of Concerns)
+Keeps business logic (`core/`) isolated from framework concerns (`controller/`) and infrastructural interfaces (`io/`). Domain rules can be tested in-memory with zero environmental dependencies.
+
+### 4. Robust Validation & Defensive Engineering
+Leverages **Pydantic v2** schemas to parse and validate parameters at the boundaries of the system. In addition, limits (such as `MAX_INPUT_ROWS` and `MAX_INPUT_COLS`) are enforced at ingestion to mitigate Algorithmic Denial of Service (DoS) attacks on compute-heavy ML algorithms.

--- a/wiki/Inference_stories.md
+++ b/wiki/Inference_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Inference Job User Story"
+description: "Define a job for generating batch predictions from a registered model."
+tags:
+  - inference
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Inference Job](backlog_mlops_regresion) : Define a job for generating batch predictions from a registered model.
 
 - [US Model Inference Job : Define a job for generating batch predictions from a registered model.](#us-model-inference-job--define-a-job-for-generating-batch-predictions-from-a-registered-model)

--- a/wiki/Metrics_stories.md
+++ b/wiki/Metrics_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Metrics User Story"
+description: "Provide standardized measurements for model performance, accuracy, and evaluation"
+tags:
+  - metrics
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Metrics](backlog_mlops_regresion) : Provide standardized measurements for model performance, accuracy, and evaluation
 
 Provide standardized measurements for model performance, accuracy, and evaluation. Useful for tracking improvement and identifying bottlenecks.

--- a/wiki/Models_stories.md
+++ b/wiki/Models_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Models User Story"
+description: "Define the structure of machine learning models, including architectures and checkpoints, to standardize training and deployment"
+tags:
+  - models
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Models](backlog_mlops_regresion) : Define the structure of machine learning models, including architectures and checkpoints, to standardize training and deployment
 
 - [US Models : Define the structure of machine learning models, including architectures and checkpoints, to standardize training and deployment](#us-models--define-the-structure-of-machine-learning-models-including-architectures-and-checkpoints-to-standardize-training-and-deployment)

--- a/wiki/OSvariables_stories.md
+++ b/wiki/OSvariables_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "IO User Story"
+description: "Provide environment variables and system-level configurations for portability across various environments."
+tags:
+  - osvariables
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [IO](backlog_mlops_regresion) :  Provide environment variables and system-level configurations for portability across various environments.
 
 - [US IO :  Provide environment variables and system-level configurations for portability across various environments.](#us-io---provide-environment-variables-and-system-level-configurations-for-portability-across-various-environments)

--- a/wiki/Promotions_stories.md
+++ b/wiki/Promotions_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Promotions User Story"
+description: "User story documentation and class details for Promotions."
+tags:
+  - promotions
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 
 # US [Model Promotion Job](backlog_mlops_regresion) : Define a job for promoting a registered model version with an alias.
 

--- a/wiki/Regristries_stories.md
+++ b/wiki/Regristries_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Registries User Story"
+description: "Model registry logicading, and registering machine learning models using MLflow."
+tags:
+  - regristries
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Registries](backlog_mlops_regresion) : Model registry logicading, and registering machine learning models using MLflow.
 
 - [US Model Registry : Manage saving, loading, and registering machine learning models using MLflow.](#us-model-registry--manage-saving-loading-and-registering-machine-learning-models-using-mlflow)

--- a/wiki/Schemas_stories.md
+++ b/wiki/Schemas_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Scchemas User Story"
+description: "Define structured data formats for input, output, and intermediate processes, ensuring consistency and validation throughout the pipeline"
+tags:
+  - schemas
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Scchemas](backlog_mlops_regresion) : Define structured data formats for input, output, and intermediate processes, ensuring consistency and validation throughout the pipeline
 
 - [US Scchemas : Define structured data formats for input, output, and intermediate processes, ensuring consistency and validation throughout the pipeline](#us-scchemas--define-structured-data-formats-for-input-output-and-intermediate-processes-ensuring-consistency-and-validation-throughout-the-pipeline)

--- a/wiki/Scripts_stories.md
+++ b/wiki/Scripts_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "CLI Application for Running AI/ML Jobs User Story"
+description: "Scripts for the CLI application"
+tags:
+  - scripts
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [CLI Application for Running AI/ML Jobs](backlog_mlops_regresion) : Scripts for the CLI application
 
 - [US CLI Application for Running AI/ML Jobs : Scripts for the CLI application](#us-cli-application-for-running-aiml-jobs--scripts-for-the-cli-application)

--- a/wiki/Searchers_stories.md
+++ b/wiki/Searchers_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Hyperparameter Searchers User Story"
+description: "Define functionalities for finding the best hyperparameters for a model."
+tags:
+  - searchers
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Hyperparameter Searchers](backlog_mlops_regresion) : Define functionalities for finding the best hyperparameters for a model.
 
 - [US Hyperparameter Searchers : Define functionalities for finding the best hyperparameters for a model.](#us-hyperparameter-searchers--define-functionalities-for-finding-the-best-hyperparameters-for-a-model)

--- a/wiki/Services_stories.md
+++ b/wiki/Services_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Services User Story"
+description: "User story documentation and class details for Services."
+tags:
+  - services
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 
 # US [Global Context Management](backlog_mlops_regresion) : Manage global contexts during execution for logging, notifications, and MLflow tracking.
 

--- a/wiki/Settings_stories.md
+++ b/wiki/Settings_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Application Settings Management User Story"
+description: "Define settings for the application."
+tags:
+  - settings
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Application Settings Management](backlog_mlops_regresion) : Define settings for the application.
 
 - [US Application Settings Management : Define settings for the application.](#us-application-settings-management--define-settings-for-the-application)

--- a/wiki/Signers_stories.md
+++ b/wiki/Signers_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Signature Generation User Story"
+description: "Generate signatures for AI/ML models."
+tags:
+  - signers
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Signature Generation](backlog_mlops_regresion) : Generate signatures for AI/ML models.
 
 - [US Model Signature Generation : Generate signatures for AI/ML models.](#us-model-signature-generation--generate-signatures-for-aiml-models)

--- a/wiki/Splitters_stories.md
+++ b/wiki/Splitters_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Data Splitting Functionality User Story"
+description: "Split dataframes into subsets for model training and evaluation."
+tags:
+  - splitters
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Data Splitting Functionality](backlog_mlops_regresion) : Split dataframes into subsets for model training and evaluation.
 
 - [US Data Splitting Functionality : Split dataframes into subsets for model training and evaluation.](#us-data-splitting-functionality--split-dataframes-into-subsets-for-model-training-and-evaluation)

--- a/wiki/Trainning_stories.md
+++ b/wiki/Trainning_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Training Job User Story"
+description: "Train, evaluate, and register a machine learning model."
+tags:
+  - trainning
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Training Job](backlog_mlops_regresion) : Train, evaluate, and register a machine learning model.
 - [US Model Training Job : Define a job for training and registering a single AI/ML model](#us-model-training-job--define-a-job-for-training-and-registering-a-single-aiml-model)
   - [classes relations](#classes-relations)

--- a/wiki/Tuning_stories.md
+++ b/wiki/Tuning_stories.md
@@ -1,3 +1,12 @@
+---
+type: UserStory
+title: "Model Tuning Job User Story"
+description: "Perform hyperparameter tuning for a model. the best hyperparameters for a model"
+tags:
+  - tuning
+  - user-story
+timestamp: "2026-04-18T12:00:00Z"
+---
 # US [Model Tuning Job](backlog_mlops_regresion) : Perform hyperparameter tuning for a model. the best hyperparameters for a model
 
 - [US Model Tuning Job : Define a job for finding the best hyperparameters for a model](#us-model-tuning-job--define-a-job-for-finding-the-best-hyperparameters-for-a-model)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,3 +1,13 @@
+---
+type: Index
+title: "Sidebar Navigation"
+description: "Sidebar containing links to various sections of the wiki."
+tags:
+  - navigation
+  - sidebar
+  - index
+timestamp: "2026-04-18T12:00:00Z"
+---
 # MLOps Python Package 📦
 
 * [🏠 Home](Home)

--- a/wiki/backlog_mlops_regresion.md
+++ b/wiki/backlog_mlops_regresion.md
@@ -1,3 +1,13 @@
+---
+type: Backlog
+title: "Backlog for Class Diagram Implementation"
+description: "The central backlog of all project features and user stories."
+tags:
+  - backlog
+  - stories
+  - project-management
+timestamp: "2026-04-18T12:00:00Z"
+---
 # Backlog for Class Diagram Implementation
 
 - [Backlog for Class Diagram Implementation](#backlog-for-class-diagram-implementation)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,41 @@
+# Index of MLOps Python Package Wiki 🗂️
+
+Welcome to the Open Knowledge Format (OKF) directory index for the MLOps Python Package. This index supports progressive disclosure, enabling humans and AI agents to discover available concept and story documents before traversing the repository.
+
+## 🧭 Main Pages
+
+- **[Home](Home)**: The central landing page describing system architecture, design patterns, context manager lifecycle, polymorphic discriminators, and design methodologies.
+- **[Backlog Overview](backlog_mlops_regresion)**: Unified product roadmap and user story backlog for class diagram implementations.
+
+## 🧠 Core Domain Concepts & User Stories
+
+- **[Models User Story](Models_stories)**: Standardizing base ML models, configurations, and baseline RandomForest wrappers via scikit-learn.
+- **[Metrics User Story](Metrics_stories)**: Unified metrics evaluation schemas and wrappers around standard scikit-learn performance statistics.
+- **[Schemas User Story](Schemas_stories)**: Data validation contracts for inputs, targets, outputs, and feature importances using Pandera and Pydantic.
+
+## 📥 Infrastructure, IO, and Environments
+
+- **[Configs User Story](Configs_stories)**: YAML and OmegaConf based hyperparameter and setting loading logic.
+- **[Datasetes User Story](Datasets_stories)**: IO mechanics for abstract and concrete readers/writers (such as ParquetReader and ParquetWriter).
+- **[OSVariables User Story](OSvariables_stories)**: Pydantic settings singleton for secure loading of environment variables and MLflow configuration.
+- **[Model Registries User Story](Regristries_stories)**: Interaction with artifacts stores and model deployment servers (MLflow registry).
+- **[Services User Story](Services_stories)**: Orchestration and life cycle management of Logging, Alerts, and MLflow tracking systems.
+
+## ⚙️ Orchestrated Workflows and Jobs
+
+- **[High-Level Project Jobs User Story](Base_stories)**: The abstract `Job` class with built-in context manager for resource setup and teardown.
+- **[Model Training Job User Story](Trainning_stories)**: Orchestrates fitting, tracking, and metric reporting for models.
+- **[Model Tuning Job User Story](Tuning_stories)**: Evaluates hyperparameter spaces using splitters and searchers.
+- **[Model Evaluations Job User Story](Evaluations_stories)**: Checks models against testing data and generates score reports.
+- **[Model Explanations Job User Story](Explanations_stories)**: Produces global feature importances and local SHAP explanation values.
+- **[Model Inference Job User Story](Inference_stories)**: Performs predictions over input files or batches.
+- **[Promotions User Story](Promotions_stories)**: Implements candidate validation and promotion to production status.
+
+## 🛠️ Auxiliary Tools & Utilities
+
+- **[Hyperparameter Searchers User Story](Searchers_stories)**: Extensible strategy class for parameter search algorithms.
+- **[Model Signature Generation User Story](Signers_stories)**: Generates deterministic structural signatures for input/output compatibility.
+- **[Data Splitting Functionality User Story](Splitters_stories)**: Reproducible cross-validation and fold splitter interfaces.
+
+---
+*Generated in accordance with Open Knowledge Format (OKF) v0.1 guidelines.*

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,12 @@
+# Change Log: MLOps Python Package Wiki 📝
+
+All notable changes to the wiki documentation bundle are recorded below.
+
+## 2026-04-18
+- **Standardized Wiki to OKF Spec**: Transformed the entire wiki directory to be fully Open Knowledge Format (OKF) v0.1 draft compliant.
+- **Added Frontmatter**: Prepend structured YAML metadata blocks with `type`, `title`, `description`, `tags`, and `timestamp` fields to all 23 non-reserved markdown files.
+- **Enriched Architecture**: Updated `Home.md` to explain modular directory relationships (`core/`, `io/`, `jobs/`, `utils/`, `controller/`), Design Patterns (Strategy, Template Method, Composition), Pydantic static/polymorphic `KIND` discriminators, OOP inheritance, context managers, and MLOps developer methodologies with real code examples.
+- **Created Reserved Files**: Added `index.md` for directory index progressive disclosure and `log.md` for tracking chronological wiki history.
+
+## 2026-04-04
+- **Initial Backlog Alignment**: Captured class-diagram-based user stories for models, metrics, jobs, datasets, configurations, and controllers.


### PR DESCRIPTION
This submission updates the entire wiki directory to be fully compliant with the Google Open Knowledge Format (OKF) v0.1 draft specification. It establishes proper metadata frontmatter blocks for every concept file, enriches Home.md with enterprise architectures and programming patterns inside the repository, and implements reserved files (index.md and log.md) to support progressive disclosure and chronological history.

---
*PR created automatically by Jules for task [13343154139205587634](https://jules.google.com/task/13343154139205587634) started by @lgcorzo*