### PR TITLE
🔒 Secure prediction result logging in Kafka consumer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Performance bottleneck and latency amplification from synchronous blocking network I/O in the core processing loop.
 **Learning:** Re-flushing the confluent_kafka producer on every single message forces the application to block on round-trip network acknowledgment for every record, severely limiting throughput.
 **Prevention:** Allow confluent_kafka to batch messages efficiently in memory by replacing `flush()` with a non-blocking `poll(0)` in the message processing loop, and calling `flush()` only during service shutdown to ensure graceful delivery of buffered messages.
+
+## 2026-04-20 - Data Exposure in Kafka Consumer Result Logging
+**Vulnerability:** Clear logging of raw prediction result which contains sensitive output data (e.g., list of inference values).
+**Learning:** Logging entire prediction payloads at DEBUG level or any other level can expose sensitive inference outputs to log aggregation and monitoring systems, violating compliance and security standards.
+**Prevention:** Avoid logging raw prediction output values. Instead, clone the dictionary and mask or summarize the sensitive prediction list (e.g., indicating the length of the list, such as `<masked_list_len_X>`) before passing it to the logger.

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -308,7 +308,14 @@ class FastAPIKafkaService:
             prediction_result = predictionresponse.result
 
         try:
-            logger.debug(f"Prediction result: {prediction_result}")
+            safe_prediction_result = prediction_result.copy() if isinstance(prediction_result, dict) else {}
+            if "inference" in safe_prediction_result:
+                inf_val = safe_prediction_result["inference"]
+                if isinstance(inf_val, list):
+                    safe_prediction_result["inference"] = f"<masked_list_len_{len(inf_val)}>"
+                else:
+                    safe_prediction_result["inference"] = "<masked>"
+            logger.debug(f"Prediction result: {safe_prediction_result}")
             if self.producer:
                 self.producer.produce(
                     self.output_topic,

--- a/tests/controller/test_log_leakage.py
+++ b/tests/controller/test_log_leakage.py
@@ -130,3 +130,62 @@ def test_kafka_consumer_log_leakage(caplog):
             break
 
     assert not found_leak, f"Sensitive value '{sensitive_value}' was found in Kafka consumer INFO logs!"
+
+
+def test_kafka_consumer_prediction_result_leakage(caplog):
+    """
+    Test that the Kafka consumer processing does not log raw prediction result values (inference)
+    at any log level, and instead uses a masked/summarized format.
+    """
+    # Setup prediction result with sensitive mock inference data
+    sensitive_inference = [999.88, 777.66, 555.44]
+
+    # Mock dependencies
+    mock_prediction_callback = MagicMock()
+    mock_prediction_callback.return_value = MagicMock(
+        result={"inference": sensitive_inference, "quality": 1.0, "error": None}
+    )
+
+    service = FastAPIKafkaService(
+        prediction_callback=mock_prediction_callback, kafka_config={}, input_topic="test", output_topic="test"
+    )
+
+    # Mock Kafka message with some valid input_data structure
+    mock_msg = MagicMock()
+    mock_msg.error.return_value = None
+    import json
+
+    kafka_msg_value = {
+        "input_data": {
+            "dteday": ["2024-01-01"],
+            "season": [1],
+        }
+    }
+    mock_msg.value.return_value = json.dumps(kafka_msg_value).encode("utf-8")
+
+    # Set log level to DEBUG so we catch all debug log statements
+    caplog.set_level(logging.DEBUG)
+
+    # Mock producer/consumer to avoid network calls
+    service.producer = MagicMock()
+    service.consumer = MagicMock()
+
+    # Process the message
+    service._process_message(mock_msg)
+
+    # Check logs for raw inference leakage vs masked logging
+    found_raw_leak = False
+    found_masked_log = False
+
+    for record in caplog.records:
+        # Check if the raw sensitive values are present in any log message
+        msg_str = record.message
+        if "999.88" in msg_str or "777.66" in msg_str or "555.44" in msg_str:
+            found_raw_leak = True
+
+        # Check if our expected masked log message is present
+        if "Prediction result:" in msg_str and "<masked_list_len_3>" in msg_str:
+            found_masked_log = True
+
+    assert not found_raw_leak, "Sensitive inference values were leaked in the logs!"
+    assert found_masked_log, "Masked/summarized prediction log was not found!"


### PR DESCRIPTION
This PR secures the prediction result logging within the Kafka consumer message loop (FastAPIKafkaService._process_message) by masking the raw inference result array before it is written to the log files. Specifically, it creates a copy of the prediction result and replaces the "inference" list with a length-based safe representation, thereby mitigating sensitive data exposure risks.

---
*PR created automatically by Jules for task [17337983213689558784](https://jules.google.com/task/17337983213689558784) started by @lgcorzo*