### PR TITLE
refactor(controller): resolve architectural, concurrency, validation,…

### DIFF
--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 import collections
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, cast
 
 import pandas as pd
 import uvicorn
@@ -375,8 +375,8 @@ async def predict(request_data: PredictionRequest, request: Request) -> Predicti
         except Exception:
             logger.info("Received HTTP prediction request with unknown data structure")
 
-        prediction_service = request.app.state.prediction_service
-        prediction_result = await run_in_threadpool(prediction_service.predict, request_data)
+        prediction_service = cast(PredictionService, request.app.state.prediction_service)
+        prediction_result: PredictionResponse = await run_in_threadpool(prediction_service.predict, request_data)
 
         logger.debug(f"HTTP prediction result: {prediction_result}")
         try:

--- a/src/regression_model_template/controller/kafka_app.py
+++ b/src/regression_model_template/controller/kafka_app.py
@@ -3,11 +3,10 @@
 import json
 import logging
 import os
-import signal
+
 import threading
 import time
 import collections
-import typing as T
 from typing import Any, Callable, Dict
 
 import pandas as pd
@@ -18,7 +17,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from regression_model_template.core.schemas import InputsSchema, Outputs
 from regression_model_template.io import registries, services
@@ -34,15 +33,11 @@ DEFAULT_FASTAPI_HOST = os.getenv("DEFAULT_FASTAPI_HOST", "127.0.0.1")
 DEFAULT_FASTAPI_PORT = int(os.getenv("DEFAULT_FASTAPI_PORT", 8100))
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+TRUSTED_PROXIES = os.getenv("TRUSTED_PROXIES", "127.0.0.1").split(",")
 LOGGING_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 MAX_INPUT_ROWS = 10000
 MAX_INPUT_COLS = 100
 MAX_TRACKED_IPS = 10000
-
-# Security Configuration
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
-ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
-TRUSTED_PROXIES = os.getenv("TRUSTED_PROXIES", "127.0.0.1").split(",")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format=LOGGING_FORMAT)
@@ -117,11 +112,11 @@ class RateLimiter:
 
 
 # Data Models
-class PredictionRequest(BaseModel):
-    """Request model for prediction."""
-
-    input_data: Dict[str, Any] = {
-        "dteday": [pd.Timestamp.now().strftime("%Y-%m-%d")] * 4,
+def default_input_payload() -> Dict[str, Any]:
+    """Generate a fresh default input payload with current timestamps."""
+    today_str = pd.Timestamp.now().strftime("%Y-%m-%d")
+    return {
+        "dteday": [today_str] * 4,
         "season": [1, 2, 3, 4],
         "yr": [0, 0, 1, 1],
         "mnth": [1, 2, 3, 4],
@@ -137,6 +132,12 @@ class PredictionRequest(BaseModel):
         "casual": [0, 10, 20, 30],
         "registered": [0, 50, 100, 150],
     }
+
+
+class PredictionRequest(BaseModel):
+    """Request model for prediction."""
+
+    input_data: Dict[str, Any] = Field(default_factory=default_input_payload)
 
     def validate_schema(self) -> pd.DataFrame:
         """Validates the input data against InputsSchema."""
@@ -212,7 +213,6 @@ class FastAPIKafkaService:
         self._initialize_kafka_consumer()
         self.server_thread = threading.Thread(target=self._run_server)
         self.server_thread.start()
-        time.sleep(2)  # Allow server to start
         threading.Thread(target=self._consume_messages, daemon=True).start()
         logger.info("FastAPI server and Kafka consumer threads started.")
 
@@ -343,12 +343,8 @@ class FastAPIKafkaService:
         if self.consumer:
             self.consumer.close()
             logger.info("Kafka consumer closed.")
-        os.kill(os.getpid(), signal.SIGINT)
         logger.info("Service stopped.")
 
-
-# Global Service Instance
-fastapi_kafka_service: "FastAPIKafkaService" = T.cast("FastAPIKafkaService", None)
 
 # Rate Limiter Instance
 predict_rate_limiter = RateLimiter(max_requests=100, window_seconds=60)
@@ -362,10 +358,8 @@ predict_rate_limiter = RateLimiter(max_requests=100, window_seconds=60)
     description="This endpoint allows you to submit data for a prediction.",
     tags=["Prediction"],
 )
-async def predict(request_data: PredictionRequest, request: Request) -> PredictionResponse:  # Use global var
+async def predict(request_data: PredictionRequest, request: Request) -> PredictionResponse:
     """Endpoint for making predictions via HTTP."""
-    global fastapi_kafka_service
-
     # Apply rate limiting
     client_ip = request.client.host if request.client else "unknown"
     if not predict_rate_limiter.is_allowed(client_ip):
@@ -381,7 +375,8 @@ async def predict(request_data: PredictionRequest, request: Request) -> Predicti
         except Exception:
             logger.info("Received HTTP prediction request with unknown data structure")
 
-        prediction_result = await run_in_threadpool(fastapi_kafka_service.prediction_callback, request_data)
+        prediction_service = request.app.state.prediction_service
+        prediction_result = await run_in_threadpool(prediction_service.predict, request_data)
 
         logger.debug(f"HTTP prediction result: {prediction_result}")
         try:
@@ -390,7 +385,7 @@ async def predict(request_data: PredictionRequest, request: Request) -> Predicti
         except Exception:
             logger.info("HTTP prediction request processed successfully")
 
-        return prediction_result  # Use the global class
+        return prediction_result
     except HTTPException:
         raise
     except Exception:
@@ -421,14 +416,13 @@ class PredictionService:
         except Exception as e:
             # Securely handle exceptions: Log details, return generic error
             logger.exception(f"Prediction failed: {e}")
-            predictionresponse.result["inference"] = 0
-            predictionresponse.result["quality"] = 0
+            predictionresponse.result["inference"] = [0.0]
+            predictionresponse.result["quality"] = 0.0
             predictionresponse.result["error"] = "An error occurred during prediction processing."
         return predictionresponse
 
 
 def main() -> None:
-    global fastapi_kafka_service
     # Configuration
     alias_or_version: str | int = "Champion"
     # Initialize Mlflow Service
@@ -441,8 +435,9 @@ def main() -> None:
     loader = CustomLoader()
     model = loader.load(uri=model_uri)
 
-    # Initialize Prediction Service
+    # Initialize Prediction Service and attach to app.state
     prediction_service = PredictionService(model)
+    app.state.prediction_service = prediction_service
 
     # Kafka Configuration
     kafka_config = {
@@ -451,13 +446,13 @@ def main() -> None:
         "auto.offset.reset": DEFAULT_AUTO_OFFSET_RESET,
     }
     # Initialize and Start Service
-    fastapi_kafka_service = FastAPIKafkaService(
+    kafka_service = FastAPIKafkaService(
         prediction_callback=prediction_service.predict,
         kafka_config=kafka_config,
         input_topic=DEFAULT_INPUT_TOPIC,
         output_topic=DEFAULT_OUTPUT_TOPIC,
     )
-    fastapi_kafka_service.start()
+    kafka_service.start()
     print("FastAPI and Kafka service is running.  Press Ctrl+C to stop.")
 
 

--- a/tests/controller/test_kafka_app.py
+++ b/tests/controller/test_kafka_app.py
@@ -27,7 +27,6 @@ def mock_kafka_service():
         patch("regression_model_template.controller.kafka_app.Producer") as MockProducer,
         patch("regression_model_template.controller.kafka_app.Consumer") as MockConsumer,
         patch("threading.Thread") as MockThread,
-        patch("time.sleep") as MockSleep,
     ):
         mock_producer = MagicMock()
         MockProducer.return_value = mock_producer
@@ -50,7 +49,7 @@ def mock_kafka_service():
             input_topic=input_topic,
             output_topic=output_topic,
         )
-        yield service, MockProducer, MockConsumer, MockThread, MockSleep
+        yield service, MockProducer, MockConsumer, MockThread
 
 
 def test_initialization(mock_kafka_service):
@@ -84,7 +83,7 @@ def test_delivery_report(mock_kafka_service):
 
 def test_start(mock_kafka_service):
     """Test the start method."""
-    service, MockProducer, MockConsumer, MockThread, MockSleep = mock_kafka_service
+    service, MockProducer, MockConsumer, MockThread = mock_kafka_service
     service.start()
 
     MockProducer.assert_called_once_with(service.kafka_config)
@@ -92,7 +91,6 @@ def test_start(mock_kafka_service):
     MockConsumer.assert_called_once_with(service.kafka_config)
     service.consumer.subscribe.assert_called_once_with([service.input_topic])
     assert MockThread.call_count == 2
-    MockSleep.assert_called_once()
 
 
 def test_start_producer_failure(mock_kafka_service):
@@ -284,14 +282,12 @@ def test_close_consumer(mock_kafka_service):
         mock_logger_info.assert_called()
 
 
-@patch("os.kill")
-def test_stop(mock_os_kill, mock_kafka_service):
+def test_stop(mock_kafka_service):
     """Test the stop method."""
     service, *_ = mock_kafka_service
     service.consumer = MagicMock()
     service.stop()
     service.consumer.close.assert_called_once()
-    mock_os_kill.assert_called_once_with(os.getpid(), signal.SIGINT)
     assert service.stop_event.is_set()
     with patch("regression_model_template.controller.kafka_app.logger.info") as mock_logger_info:
         service.stop()
@@ -301,27 +297,31 @@ def test_stop(mock_os_kill, mock_kafka_service):
 
 @pytest.mark.asyncio
 async def test_predict_endpoint():
-    with patch("regression_model_template.controller.kafka_app.fastapi_kafka_service") as mock_fastapi_kafka_service:
-        mock_fastapi_kafka_service.prediction_callback.return_value = PredictionResponse(
-            result={"inference": [1.0], "quality": 1.0, "error": None}
-        )
-        with patch("regression_model_template.controller.kafka_app.logger.debug") as mock_logger_debug:
-            request_data = PredictionRequest()
-            mock_request = MagicMock()
-            mock_request.client.host = "127.0.0.1"
-            response = await predict(request_data, mock_request)
-            assert response.result["inference"] == [1.0]
-            mock_logger_debug.assert_called()
+    mock_prediction_service = MagicMock()
+    mock_prediction_service.predict.return_value = PredictionResponse(
+        result={"inference": [1.0], "quality": 1.0, "error": None}
+    )
+    app.state.prediction_service = mock_prediction_service
+    with patch("regression_model_template.controller.kafka_app.logger.debug") as mock_logger_debug:
+        request_data = PredictionRequest()
+        mock_request = MagicMock()
+        mock_request.app = app
+        mock_request.client.host = "127.0.0.1"
+        response = await predict(request_data, mock_request)
+        assert response.result["inference"] == [1.0]
+        mock_logger_debug.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_predict_endpoint_exception():
-    with patch("regression_model_template.controller.kafka_app.fastapi_kafka_service") as mock_fastapi_kafka_service:
-        mock_fastapi_kafka_service.prediction_callback.side_effect = Exception("Test Exception")
-        with pytest.raises(HTTPException):
-            mock_request = MagicMock()
-            mock_request.client.host = "127.0.0.1"
-            await predict(PredictionRequest(), mock_request)
+    mock_prediction_service = MagicMock()
+    mock_prediction_service.predict.side_effect = Exception("Test Exception")
+    app.state.prediction_service = mock_prediction_service
+    with pytest.raises(HTTPException):
+        mock_request = MagicMock()
+        mock_request.app = app
+        mock_request.client.host = "127.0.0.1"
+        await predict(PredictionRequest(), mock_request)
 
 
 @pytest.mark.asyncio

--- a/tests/controller/test_kafka_app.py
+++ b/tests/controller/test_kafka_app.py
@@ -1,6 +1,4 @@
 import json
-import os
-import signal
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/controller/test_kafka_app_logging.py
+++ b/tests/controller/test_kafka_app_logging.py
@@ -45,32 +45,34 @@ def mock_kafka_service():
 @patch("regression_model_template.controller.kafka_app.logger")
 async def test_predict_endpoint_logging(mock_logger):
     """Test that the HTTP predict endpoint logs correctly using debug and safe info logs."""
+    from regression_model_template.controller.kafka_app import app
 
-    with patch("regression_model_template.controller.kafka_app.fastapi_kafka_service") as mock_fastapi_kafka_service:
-        # Provide a valid prediction response
-        mock_response = PredictionResponse(result={"inference": [1.0], "quality": 1.0, "error": None})
-        mock_fastapi_kafka_service.prediction_callback.return_value = mock_response
+    mock_prediction_service = MagicMock()
+    mock_response = PredictionResponse(result={"inference": [1.0], "quality": 1.0, "error": None})
+    mock_prediction_service.predict.return_value = mock_response
+    app.state.prediction_service = mock_prediction_service
 
-        request_data = PredictionRequest()
-        mock_request = MagicMock()
-        mock_request.client.host = "127.0.0.1"
-        response = await predict(request_data, mock_request)
+    request_data = PredictionRequest()
+    mock_request = MagicMock()
+    mock_request.app = app
+    mock_request.client.host = "127.0.0.1"
+    response = await predict(request_data, mock_request)
 
-        # Verify the response is returned
-        assert response == mock_response
+    # Verify the response is returned
+    assert response == mock_response
 
-        # Verify debug log was called with the request
-        mock_logger.debug.assert_any_call(f"Received HTTP prediction request: {request_data}")
+    # Verify debug log was called with the request
+    mock_logger.debug.assert_any_call(f"Received HTTP prediction request: {request_data}")
 
-        # Verify safe info log was called
-        expected_cols = len(request_data.input_data)
-        mock_logger.info.assert_any_call(f"Received HTTP prediction request with 4 rows and {expected_cols} columns")
+    # Verify safe info log was called
+    expected_cols = len(request_data.input_data)
+    mock_logger.info.assert_any_call(f"Received HTTP prediction request with 4 rows and {expected_cols} columns")
 
-        # Verify debug log was called with the result
-        mock_logger.debug.assert_any_call(f"HTTP prediction result: {mock_response}")
+    # Verify debug log was called with the result
+    mock_logger.debug.assert_any_call(f"HTTP prediction result: {mock_response}")
 
-        # Verify safe result info log was called
-        mock_logger.info.assert_any_call("HTTP prediction request processed successfully with status: success")
+    # Verify safe result info log was called
+    mock_logger.info.assert_any_call("HTTP prediction request processed successfully with status: success")
 
 
 @patch("regression_model_template.controller.kafka_app.logger")

--- a/tests/controller/test_kafka_app_security.py
+++ b/tests/controller/test_kafka_app_security.py
@@ -27,8 +27,8 @@ def test_prediction_service_sanitization():
     # Verify
     assert response.result["error"] == "An error occurred during prediction processing."
     assert sensitive_error not in response.result["error"]
-    assert response.result["quality"] == 0
-    assert response.result["inference"] == 0
+    assert response.result["quality"] == 0.0
+    assert response.result["inference"] == [0.0]
 
 
 @pytest.mark.asyncio
@@ -64,22 +64,22 @@ def test_predict_endpoint_exception_leak():
     """Test that the predict endpoint does NOT leak exception details."""
 
     async def run_async_test():
-        with patch(
-            "regression_model_template.controller.kafka_app.fastapi_kafka_service", create=True
-        ) as mock_fastapi_kafka_service:
-            # Simulate a sensitive internal error raised by callback (unlikely now with PredictionService, but possible if something else fails)
-            sensitive_error_message = "Database connection failed at 192.168.1.100:5432"
-            mock_fastapi_kafka_service.prediction_callback.side_effect = Exception(sensitive_error_message)
+        from regression_model_template.controller.kafka_app import app
+        mock_prediction_service = MagicMock()
+        sensitive_error_message = "Database connection failed at 192.168.1.100:5432"
+        mock_prediction_service.predict.side_effect = Exception(sensitive_error_message)
+        app.state.prediction_service = mock_prediction_service
 
-            # Expect an HTTPException
-            with pytest.raises(HTTPException) as excinfo:
-                mock_request = MagicMock()
-                mock_request.client.host = "127.0.0.1"
-                await predict(PredictionRequest(), mock_request)
+        # Expect an HTTPException
+        with pytest.raises(HTTPException) as excinfo:
+            mock_request = MagicMock()
+            mock_request.app = app
+            mock_request.client.host = "127.0.0.1"
+            await predict(PredictionRequest(), mock_request)
 
-            # Verify that the sensitive message is leaked in the detail
-            assert excinfo.value.status_code == 500
-            assert excinfo.value.detail == "Internal Server Error"
-            assert excinfo.value.detail != sensitive_error_message
+        # Verify that the sensitive message is leaked in the detail
+        assert excinfo.value.status_code == 500
+        assert excinfo.value.detail == "Internal Server Error"
+        assert excinfo.value.detail != sensitive_error_message
 
     asyncio.run(run_async_test())

--- a/tests/controller/test_kafka_app_security.py
+++ b/tests/controller/test_kafka_app_security.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -65,6 +65,7 @@ def test_predict_endpoint_exception_leak():
 
     async def run_async_test():
         from regression_model_template.controller.kafka_app import app
+
         mock_prediction_service = MagicMock()
         sensitive_error_message = "Database connection failed at 192.168.1.100:5432"
         mock_prediction_service.predict.side_effect = Exception(sensitive_error_message)

--- a/tests/controller/test_log_leakage.py
+++ b/tests/controller/test_log_leakage.py
@@ -1,6 +1,6 @@
 import pytest
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from regression_model_template.controller.kafka_app import PredictionRequest, predict, FastAPIKafkaService
 import pandas as pd
 
@@ -57,10 +57,9 @@ async def test_predict_log_leakage(caplog):
 
     # Mock the service
     from regression_model_template.controller.kafka_app import app
+
     mock_prediction_service = MagicMock()
-    mock_prediction_service.predict.return_value = MagicMock(
-        result={"inference": [0.0], "quality": 1.0, "error": ""}
-    )
+    mock_prediction_service.predict.return_value = MagicMock(result={"inference": [0.0], "quality": 1.0, "error": ""})
     app.state.prediction_service = mock_prediction_service
 
     # Configure logging capture

--- a/tests/controller/test_log_leakage.py
+++ b/tests/controller/test_log_leakage.py
@@ -56,30 +56,32 @@ async def test_predict_log_leakage(caplog):
         request.__repr__.return_value = str(request_data)
 
     # Mock the service
-    with patch("regression_model_template.controller.kafka_app.fastapi_kafka_service") as mock_service:
-        # Mock the callback to return a successful result so the function completes
-        mock_service.prediction_callback.return_value = MagicMock(
-            result={"inference": [0.0], "quality": 1.0, "error": ""}
-        )
+    from regression_model_template.controller.kafka_app import app
+    mock_prediction_service = MagicMock()
+    mock_prediction_service.predict.return_value = MagicMock(
+        result={"inference": [0.0], "quality": 1.0, "error": ""}
+    )
+    app.state.prediction_service = mock_prediction_service
 
-        # Configure logging capture
-        caplog.set_level(logging.INFO)
+    # Configure logging capture
+    caplog.set_level(logging.INFO)
 
-        # Call the endpoint
-        mock_request = MagicMock()
-        mock_request.client.host = "127.0.0.1"
-        await predict(request, mock_request)
+    # Call the endpoint
+    mock_request = MagicMock()
+    mock_request.app = app
+    mock_request.client.host = "127.0.0.1"
+    await predict(request, mock_request)
 
-        # Check logs for leakage
-        # If the sensitive value appears in the INFO logs, this assertion will fail
-        # confirming the vulnerability.
-        found_leak = False
-        for record in caplog.records:
-            if sensitive_value in record.message and record.levelno == logging.INFO:
-                found_leak = True
-                break
+    # Check logs for leakage
+    # If the sensitive value appears in the INFO logs, this assertion will fail
+    # confirming the vulnerability.
+    found_leak = False
+    for record in caplog.records:
+        if sensitive_value in record.message and record.levelno == logging.INFO:
+            found_leak = True
+            break
 
-        assert not found_leak, f"Sensitive value '{sensitive_value}' was found in INFO logs!"
+    assert not found_leak, f"Sensitive value '{sensitive_value}' was found in INFO logs!"
 
 
 def test_kafka_consumer_log_leakage(caplog):


### PR DESCRIPTION
… and maintainability issues in kafka_app.py

- Remove duplicate ALLOWED_HOSTS and ALLOWED_ORIGINS constant declarations
- Replace mutable dict default in PredictionRequest with Field(default_factory=...)
- Eliminate global fastapi_kafka_service by utilizing FastAPI app.state dependency injection
- Fix type inconsistency on PredictionService error paths to return list [0.0] instead of int 0
- Remove hacky os.kill(SIGINT) shutdown in favor of clean stop_event and consumer handling
- Update test suite to reflect app.state injection and new error return types

# Changes

# Reasons

# Testing

# Impacts

# Notes
