### PR TITLE
Fix idempotency of doc_generator.py flowcharts

### DIFF
--- a/doc_generator.py
+++ b/doc_generator.py
@@ -230,7 +230,7 @@ def process_file(filepath, commit_hash):
                                         or "Dependencies found" in block_content
                                     )
                                 ):
-                                    new_block = "\n" + flowchart[23:] + parts[i][end_idx + 3 :]
+                                    new_block = flowchart[23:] + parts[i][end_idx + 3 :]
                                     if parts[i] != new_block:
                                         parts[i] = new_block
                                         changed = True

--- a/test_doc_generator.py
+++ b/test_doc_generator.py
@@ -1,0 +1,12 @@
+import doc_generator
+import os
+
+def test_flowchart():
+    classes, imports = doc_generator.parse_ast("src/regression_model_template/controller/kafka_app.py")
+    flowchart = doc_generator.generate_flowchart("kafka_app", imports)
+
+    assert "```mermaid\nflowchart TD" in flowchart
+    assert "kafka_app --> collections" in flowchart
+
+test_flowchart()
+print("doc_generator logic tests pass")


### PR DESCRIPTION
Fixed an issue in `doc_generator.py` where updating Mermaid flowcharts would inject an extra newline character upon every run, causing unaffected wiki markdown files to drift statelessly and cluttering the git history. Cleaned up the working tree.

---
*PR created automatically by Jules for task [18429758531700517472](https://jules.google.com/task/18429758531700517472) started by @lgcorzo*