### PR TITLE
ci: exclude wiki and openwiki files from CI check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'Documents/**'
       - 'docs/**'
+      - 'wiki/**'
+      - 'openwiki/**'
       - '**/*.md'
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
Excludes wiki/** and openwiki/** from triggering pull request CI checks.