### PR TITLE
docs: add fmind/mlops-python-package to resources in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,5 +1269,6 @@ This section provides resources for building packages for Python and AI/ML/MLOps
 
 ## AI/ML/MLOps
 
+- https://github.com/fmind/mlops-python-package
 - https://github.com/josephmisiti/awesome-machine-learning
 - https://github.com/visenger/awesome-mlops


### PR DESCRIPTION
Adds https://github.com/fmind/mlops-python-package reference to the Resources section in README.md.