### PR TITLE
fix(deps): address dependabot vulnerability by pinning cryptography

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "pyopenssl (>=26.0.0,<27.0.0)",
     "diskcache (>=5.6.3,<6.0.0)",
     "starlette (>=0.50.0,<1.0.0)",
+    # explicitly define secure version for transitive dependency cryptography (April 2026 environment)
+    "cryptography (>=46.0.6,<50.0.0)",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Addresses Dependabot security vulnerabilities in the `lgcorzo/mlops-python-package` repository by explicitly pinning the `cryptography` dependency to a secure version in `pyproject.toml`. This resolves a transitive dependency vulnerability while adhering to the specified April 2026 environmental constraints.

---
*PR created automatically by Jules for task [17048077429276313380](https://jules.google.com/task/17048077429276313380) started by @lgcorzo*