### PR TITLE
docs(okf): add strict requirements for class diagram relationships

### DIFF
--- a/.agents/skills/okf-professional-documenter/SKILL.md
+++ b/.agents/skills/okf-professional-documenter/SKILL.md
@@ -115,6 +115,10 @@ last_verified_commit: "a1b2c3d"
   - Annotate interfaces with `<<interface>>` and abstract classes with `<<abstract>>`.
   - Explicitly show polymorphism: repeat overridden methods in subclasses, using a trailing asterisk (e.g. `parse()*`) or bolding to differentiate abstract or overridden behavior.
   - Represent encapsulation visibility markers: `+` (public), `-` (private), `#` (protected), `~` (package/internal).
+- **Relationships & Associations**:
+  - Clearly define the class heritage and inheritance trees.
+  - Clearly define structural and behavioral relationships with other classes within the same package.
+  - Clearly define relationships and dependencies with classes in sub-packages (the packages below in the folder hierarchy).
 - Derive all relationships from Pyreverse/Graphify AST data.
 
 ### 2. Sequence Diagrams (`sequenceDiagram`)


### PR DESCRIPTION
Adds strict rules for generating UML 2.0 Class Diagrams (Relationships & Associations) to the `okf-professional-documenter` skill agent definition.

---
*PR created automatically by Jules for task [198731307576052296](https://jules.google.com/task/198731307576052296) started by @lgcorzo*