### PR TITLE
Fix poetry.lock sync with pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8759,4 +8759,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "06124a5a8466649e6f0cd58da9f896bc8c96b35ab2e78ebb6866c6bda7935e89"
+content-hash = "2e09ae3bfd0d100afda0dba42153fc6c989529015602cf6a42f68fc028290276"


### PR DESCRIPTION
Fixed the `poetry.lock` inconsistency issue that was causing `invoke checks` to fail. The failure message indicated that `pyproject.toml` had changed significantly and was out of sync with `poetry.lock`. Ran `poetry lock` to regenerate the lockfile, and verified all tests pass locally.

---
*PR created automatically by Jules for task [199834304634531080](https://jules.google.com/task/199834304634531080) started by @lgcorzo*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lgcorzo/mlops-python-package/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->