### PR TITLE
Fix deterministic diagram generation in openwiki script

### DIFF
--- a/generate_openwiki.py
+++ b/generate_openwiki.py
@@ -308,13 +308,13 @@ def build_registry(files_to_process):
 
 def generate_package_diagram_content():
     lines = ["```plantuml", 'package "src" {']
-    packages = set()
+    packages = {}
     for py_file in registry["modules"].keys():
         parts = py_file.split("/")[:-1]
         pkg = ".".join(parts)
         if pkg:
-            packages.add(pkg)
-    for pkg in sorted(packages):
+            packages[pkg] = None
+    for pkg in sorted(packages.keys()):
         lines.append(f'    package "{pkg}" {{}}')
     lines.append("}")
     lines.append("```")
@@ -325,28 +325,28 @@ def generate_call_graph():
     lines = ["```plantuml", "digraph CallGraph {"]
 
     # Build a list of all defined functions/methods across the project to map internal calls
-    defined_callables = set()
+    defined_callables = {}
     for mod_path, data in registry["modules"].items():
         for func in data["functions"]:
-            defined_callables.add(func["name"])
+            defined_callables[func["name"]] = None
         for cls in data["classes"]:
-            defined_callables.add(cls["name"])
+            defined_callables[cls["name"]] = None
             for m in cls["methods"]:
-                defined_callables.add(m["name"])
+                defined_callables[m["name"]] = None
 
-    edges = set()
+    edges = {}
     for mod_path, data in registry["modules"].items():
         for func in data["functions"]:
             for call in func.get("calls", []):
                 if call in defined_callables:
-                    edges.add(f'    "{func["name"]}()" -> "{call}()"')
+                    edges[f'    "{func["name"]}()" -> "{call}()"'] = None
         for cls in data["classes"]:
             for m in cls.get("methods", []):
                 for call in m.get("calls", []):
                     if call in defined_callables:
-                        edges.add(f'    "{cls["name"]}.{m["name"]}()" -> "{call}()"')
+                        edges[f'    "{cls["name"]}.{m["name"]}()" -> "{call}()"'] = None
 
-    for edge in sorted(edges):
+    for edge in sorted(edges.keys()):
         lines.append(edge)
 
     lines.append("}")
@@ -664,7 +664,7 @@ def main():
         files_to_process = all_files
     else:
         changed_files = get_changed_files()
-        impacted_files = set(changed_files)
+        impacted_files_dict = {f: None for f in changed_files}
 
         # In diff mode, we need to include files that depend on the changed files or are dependencies of them.
         for changed_file in changed_files:
@@ -673,14 +673,14 @@ def main():
 
             # Find files that import this changed file
             for other_py, other_data in registry["modules"].items():
-                if other_py in impacted_files:
+                if other_py in impacted_files_dict:
                     continue
                 for imp in other_data["imports"]:
                     if mod_path_dotted in imp or imp.startswith(mod_name):
-                        impacted_files.add(other_py)
+                        impacted_files_dict[other_py] = None
                         break
 
-        files_to_process = list(impacted_files)
+        files_to_process = list(impacted_files_dict.keys())
 
     print(f"Mode: {args.mode}")
     print(f"Files to process: {len(files_to_process)}")

--- a/openwiki/SUMMARY.md
+++ b/openwiki/SUMMARY.md
@@ -5,10 +5,10 @@ type: "summary"
 title: "Summary"
 description: "Auto-generated summary."
 tags: ["summary"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Summary
 

--- a/openwiki/architecture/diagrams.md
+++ b/openwiki/architecture/diagrams.md
@@ -5,10 +5,10 @@ type: "diagrams"
 title: "Diagrams"
 description: "Auto-generated architecture diagrams."
 tags: ["diagrams"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Architecture Diagrams
 

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -5,10 +5,10 @@ type: "index"
 title: "Index"
 description: "Auto-generated index."
 tags: ["index"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Index
 

--- a/openwiki/modules/generate_openwiki.md
+++ b/openwiki/modules/generate_openwiki.md
@@ -6,10 +6,10 @@ title: "Module: generate_openwiki"
 source_path: "generate_openwiki.py"
 description: "No description available."
 tags: ["module", "generate_openwiki"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: generate_openwiki
 
@@ -87,19 +87,16 @@ sequenceDiagram
     generate_plantuml->>clean_plantuml_type: invoke
     generate_plantuml->>split: invoke
     build_registry->>parse_python_file: invoke
-    generate_package_diagram_content->>set: invoke
     generate_package_diagram_content->>keys: invoke
     generate_package_diagram_content->>sorted: invoke
     generate_package_diagram_content->>append: invoke
     generate_package_diagram_content->>join: invoke
     generate_package_diagram_content->>split: invoke
-    generate_package_diagram_content->>add: invoke
-    generate_call_graph->>set: invoke
     generate_call_graph->>items: invoke
     generate_call_graph->>sorted: invoke
     generate_call_graph->>append: invoke
     generate_call_graph->>join: invoke
-    generate_call_graph->>add: invoke
+    generate_call_graph->>keys: invoke
     generate_call_graph->>get: invoke
     generate_dependency_graph->>items: invoke
     generate_dependency_graph->>append: invoke
@@ -156,7 +153,6 @@ sequenceDiagram
     main->>update_index_files: invoke
     main->>delete_generated_docs: invoke
     main->>get_changed_files: invoke
-    main->>set: invoke
     main->>list: invoke
     main->>get: invoke
     main->>join: invoke
@@ -164,6 +160,7 @@ sequenceDiagram
     main->>endswith: invoke
     main->>replace: invoke
     main->>items: invoke
+    main->>keys: invoke
     main->>parse_python_file: invoke
     main->>startswith: invoke
     main->>dirname: invoke
@@ -174,7 +171,6 @@ sequenceDiagram
     main->>splitext: invoke
     main->>len: invoke
     main->>basename: invoke
-    main->>add: invoke
 ```
 
 ### Component Diagram

--- a/openwiki/modules/regression_model_template/__init__.md
+++ b/openwiki/modules/regression_model_template/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/__init__.py"
 description: "Predict the number of regression_model_template available."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/__main__.md
+++ b/openwiki/modules/regression_model_template/__main__.md
@@ -6,10 +6,10 @@ title: "Module: __main__"
 source_path: "src/regression_model_template/__main__.py"
 description: "Entry point of the package."
 tags: ["module", "__main__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __main__
 

--- a/openwiki/modules/regression_model_template/controller/__init__.md
+++ b/openwiki/modules/regression_model_template/controller/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/controller/__init__.py"
 description: "Predict the number of regression_model_template available."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/controller/kafka_app.md
+++ b/openwiki/modules/regression_model_template/controller/kafka_app.md
@@ -6,10 +6,10 @@ title: "Module: kafka_app"
 source_path: "src/regression_model_template/controller/kafka_app.py"
 description: "FastAPI and Kafka Service for Predictions with Logging."
 tags: ["module", "kafka_app"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: kafka_app
 

--- a/openwiki/modules/regression_model_template/core/__init__.md
+++ b/openwiki/modules/regression_model_template/core/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/core/__init__.py"
 description: "Core components of the project."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/core/metrics.md
+++ b/openwiki/modules/regression_model_template/core/metrics.md
@@ -6,10 +6,10 @@ title: "Module: metrics"
 source_path: "src/regression_model_template/core/metrics.py"
 description: "Evaluate model performances with metrics."
 tags: ["module", "metrics"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: metrics
 

--- a/openwiki/modules/regression_model_template/core/models.md
+++ b/openwiki/modules/regression_model_template/core/models.md
@@ -6,10 +6,10 @@ title: "Module: models"
 source_path: "src/regression_model_template/core/models.py"
 description: "Define trainable machine learning models."
 tags: ["module", "models"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: models
 

--- a/openwiki/modules/regression_model_template/core/schemas.md
+++ b/openwiki/modules/regression_model_template/core/schemas.md
@@ -6,10 +6,10 @@ title: "Module: schemas"
 source_path: "src/regression_model_template/core/schemas.py"
 description: "Define and validate dataframe schemas."
 tags: ["module", "schemas"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: schemas
 

--- a/openwiki/modules/regression_model_template/init_data.md
+++ b/openwiki/modules/regression_model_template/init_data.md
@@ -6,10 +6,10 @@ title: "Module: init_data"
 source_path: "src/regression_model_template/init_data.py"
 description: "Script to initialize synthetic train and test parquet datasets."
 tags: ["module", "init_data"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: init_data
 

--- a/openwiki/modules/regression_model_template/io/__init__.md
+++ b/openwiki/modules/regression_model_template/io/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/io/__init__.py"
 description: "Components related to external operations."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/io/configs.md
+++ b/openwiki/modules/regression_model_template/io/configs.md
@@ -6,10 +6,10 @@ title: "Module: configs"
 source_path: "src/regression_model_template/io/configs.py"
 description: "Parse, merge, and convert config objects."
 tags: ["module", "configs"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: configs
 

--- a/openwiki/modules/regression_model_template/io/datasets.md
+++ b/openwiki/modules/regression_model_template/io/datasets.md
@@ -6,10 +6,10 @@ title: "Module: datasets"
 source_path: "src/regression_model_template/io/datasets.py"
 description: "Read/Write datasets from/to external sources/destinations."
 tags: ["module", "datasets"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: datasets
 

--- a/openwiki/modules/regression_model_template/io/osvariables.md
+++ b/openwiki/modules/regression_model_template/io/osvariables.md
@@ -6,10 +6,10 @@ title: "Module: osvariables"
 source_path: "src/regression_model_template/io/osvariables.py"
 description: "No description available."
 tags: ["module", "osvariables"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: osvariables
 

--- a/openwiki/modules/regression_model_template/io/registries.md
+++ b/openwiki/modules/regression_model_template/io/registries.md
@@ -6,10 +6,10 @@ title: "Module: registries"
 source_path: "src/regression_model_template/io/registries.py"
 description: "Savers, loaders, and registers for model registries."
 tags: ["module", "registries"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: registries
 

--- a/openwiki/modules/regression_model_template/io/services.md
+++ b/openwiki/modules/regression_model_template/io/services.md
@@ -6,10 +6,10 @@ title: "Module: services"
 source_path: "src/regression_model_template/io/services.py"
 description: "Manage global context during execution."
 tags: ["module", "services"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: services
 

--- a/openwiki/modules/regression_model_template/jobs/__init__.md
+++ b/openwiki/modules/regression_model_template/jobs/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/jobs/__init__.py"
 description: "High-level jobs of the project."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/jobs/base.md
+++ b/openwiki/modules/regression_model_template/jobs/base.md
@@ -6,10 +6,10 @@ title: "Module: base"
 source_path: "src/regression_model_template/jobs/base.py"
 description: "Base for high-level project jobs."
 tags: ["module", "base"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: base
 

--- a/openwiki/modules/regression_model_template/jobs/evaluations.md
+++ b/openwiki/modules/regression_model_template/jobs/evaluations.md
@@ -6,10 +6,10 @@ title: "Module: evaluations"
 source_path: "src/regression_model_template/jobs/evaluations.py"
 description: "Define a job for evaluating registered models with data."
 tags: ["module", "evaluations"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: evaluations
 

--- a/openwiki/modules/regression_model_template/jobs/explanations.md
+++ b/openwiki/modules/regression_model_template/jobs/explanations.md
@@ -6,10 +6,10 @@ title: "Module: explanations"
 source_path: "src/regression_model_template/jobs/explanations.py"
 description: "Define a job for explaining the model structure and decisions."
 tags: ["module", "explanations"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: explanations
 

--- a/openwiki/modules/regression_model_template/jobs/inference.md
+++ b/openwiki/modules/regression_model_template/jobs/inference.md
@@ -6,10 +6,10 @@ title: "Module: inference"
 source_path: "src/regression_model_template/jobs/inference.py"
 description: "Define a job for generating batch predictions from a registered model."
 tags: ["module", "inference"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: inference
 

--- a/openwiki/modules/regression_model_template/jobs/promotion.md
+++ b/openwiki/modules/regression_model_template/jobs/promotion.md
@@ -6,10 +6,10 @@ title: "Module: promotion"
 source_path: "src/regression_model_template/jobs/promotion.py"
 description: "Define a job for promoting a registered model version with an alias."
 tags: ["module", "promotion"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: promotion
 

--- a/openwiki/modules/regression_model_template/jobs/training.md
+++ b/openwiki/modules/regression_model_template/jobs/training.md
@@ -6,10 +6,10 @@ title: "Module: training"
 source_path: "src/regression_model_template/jobs/training.py"
 description: "Define a job for training and registring a single AI/ML model."
 tags: ["module", "training"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: training
 

--- a/openwiki/modules/regression_model_template/jobs/tuning.md
+++ b/openwiki/modules/regression_model_template/jobs/tuning.md
@@ -6,10 +6,10 @@ title: "Module: tuning"
 source_path: "src/regression_model_template/jobs/tuning.py"
 description: "Define a job for finding the best hyperparameters for a model."
 tags: ["module", "tuning"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: tuning
 

--- a/openwiki/modules/regression_model_template/scripts.md
+++ b/openwiki/modules/regression_model_template/scripts.md
@@ -6,10 +6,10 @@ title: "Module: scripts"
 source_path: "src/regression_model_template/scripts.py"
 description: "Scripts for the CLI application."
 tags: ["module", "scripts"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: scripts
 

--- a/openwiki/modules/regression_model_template/settings.md
+++ b/openwiki/modules/regression_model_template/settings.md
@@ -6,10 +6,10 @@ title: "Module: settings"
 source_path: "src/regression_model_template/settings.py"
 description: "Define settings for the application."
 tags: ["module", "settings"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: settings
 

--- a/openwiki/modules/regression_model_template/utils/__init__.md
+++ b/openwiki/modules/regression_model_template/utils/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "src/regression_model_template/utils/__init__.py"
 description: "Helper components of the project."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/regression_model_template/utils/searchers.md
+++ b/openwiki/modules/regression_model_template/utils/searchers.md
@@ -6,10 +6,10 @@ title: "Module: searchers"
 source_path: "src/regression_model_template/utils/searchers.py"
 description: "Find the best hyperparameters for a model."
 tags: ["module", "searchers"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: searchers
 

--- a/openwiki/modules/regression_model_template/utils/signers.md
+++ b/openwiki/modules/regression_model_template/utils/signers.md
@@ -6,10 +6,10 @@ title: "Module: signers"
 source_path: "src/regression_model_template/utils/signers.py"
 description: "Generate signatures for AI/ML models."
 tags: ["module", "signers"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: signers
 

--- a/openwiki/modules/regression_model_template/utils/splitters.md
+++ b/openwiki/modules/regression_model_template/utils/splitters.md
@@ -6,10 +6,10 @@ title: "Module: splitters"
 source_path: "src/regression_model_template/utils/splitters.py"
 description: "Split dataframes into subsets (e.g., train/valid/test)."
 tags: ["module", "splitters"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: splitters
 

--- a/openwiki/modules/skills/validate/scripts/convert_links.md
+++ b/openwiki/modules/skills/validate/scripts/convert_links.md
@@ -6,10 +6,10 @@ title: "Module: convert_links"
 source_path: "skills/validate/scripts/convert_links.py"
 description: "No description available."
 tags: ["module", "convert_links"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: convert_links
 

--- a/openwiki/modules/skills/validate/scripts/okf_validate.md
+++ b/openwiki/modules/skills/validate/scripts/okf_validate.md
@@ -6,10 +6,10 @@ title: "Module: okf_validate"
 source_path: "skills/validate/scripts/okf_validate.py"
 description: "OKF v0.2 Conformance Checker for OpenWiki Documentation."
 tags: ["module", "okf_validate"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: okf_validate
 

--- a/openwiki/modules/tasks/__init__.md
+++ b/openwiki/modules/tasks/__init__.md
@@ -6,10 +6,10 @@ title: "Module: __init__"
 source_path: "tasks/__init__.py"
 description: "Task collections for the project."
 tags: ["module", "__init__"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: __init__
 

--- a/openwiki/modules/tasks/checks.md
+++ b/openwiki/modules/tasks/checks.md
@@ -6,10 +6,10 @@ title: "Module: checks"
 source_path: "tasks/checks.py"
 description: "Check tasks for pyinvoke."
 tags: ["module", "checks"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: checks
 

--- a/openwiki/modules/tasks/cleans.md
+++ b/openwiki/modules/tasks/cleans.md
@@ -6,10 +6,10 @@ title: "Module: cleans"
 source_path: "tasks/cleans.py"
 description: "Clean tasks for pyinvoke."
 tags: ["module", "cleans"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: cleans
 

--- a/openwiki/modules/tasks/commits.md
+++ b/openwiki/modules/tasks/commits.md
@@ -6,10 +6,10 @@ title: "Module: commits"
 source_path: "tasks/commits.py"
 description: "Commits tasks for pyinvoke."
 tags: ["module", "commits"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: commits
 

--- a/openwiki/modules/tasks/containers.md
+++ b/openwiki/modules/tasks/containers.md
@@ -6,10 +6,10 @@ title: "Module: containers"
 source_path: "tasks/containers.py"
 description: "Container tasks for pyinvoke."
 tags: ["module", "containers"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: containers
 

--- a/openwiki/modules/tasks/docs.md
+++ b/openwiki/modules/tasks/docs.md
@@ -6,10 +6,10 @@ title: "Module: docs"
 source_path: "tasks/docs.py"
 description: "Docs tasks for pyinvoke."
 tags: ["module", "docs"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: docs
 

--- a/openwiki/modules/tasks/formats.md
+++ b/openwiki/modules/tasks/formats.md
@@ -6,10 +6,10 @@ title: "Module: formats"
 source_path: "tasks/formats.py"
 description: "Format tasks for pyinvoke."
 tags: ["module", "formats"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: formats
 

--- a/openwiki/modules/tasks/installs.md
+++ b/openwiki/modules/tasks/installs.md
@@ -6,10 +6,10 @@ title: "Module: installs"
 source_path: "tasks/installs.py"
 description: "Install tasks for pyinvoke."
 tags: ["module", "installs"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: installs
 

--- a/openwiki/modules/tasks/mlflow.md
+++ b/openwiki/modules/tasks/mlflow.md
@@ -6,10 +6,10 @@ title: "Module: mlflow"
 source_path: "tasks/mlflow.py"
 description: "Mlflow tasks for pyinvoke."
 tags: ["module", "mlflow"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: mlflow
 

--- a/openwiki/modules/tasks/packages.md
+++ b/openwiki/modules/tasks/packages.md
@@ -6,10 +6,10 @@ title: "Module: packages"
 source_path: "tasks/packages.py"
 description: "Package tasks for pyinvoke."
 tags: ["module", "packages"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: packages
 

--- a/openwiki/modules/tasks/projects.md
+++ b/openwiki/modules/tasks/projects.md
@@ -6,10 +6,10 @@ title: "Module: projects"
 source_path: "tasks/projects.py"
 description: "Project tasks for pyinvoke."
 tags: ["module", "projects"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: projects
 

--- a/openwiki/modules/tests/conftest.md
+++ b/openwiki/modules/tests/conftest.md
@@ -6,10 +6,10 @@ title: "Module: conftest"
 source_path: "tests/conftest.py"
 description: "Configuration for the tests."
 tags: ["module", "conftest"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: conftest
 

--- a/openwiki/modules/tests/controller/simulated_integration_test.md
+++ b/openwiki/modules/tests/controller/simulated_integration_test.md
@@ -6,10 +6,10 @@ title: "Module: simulated_integration_test"
 source_path: "tests/controller/simulated_integration_test.py"
 description: "No description available."
 tags: ["module", "simulated_integration_test"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: simulated_integration_test
 

--- a/openwiki/modules/tests/controller/test_kafka_app.md
+++ b/openwiki/modules/tests/controller/test_kafka_app.md
@@ -6,10 +6,10 @@ title: "Module: test_kafka_app"
 source_path: "tests/controller/test_kafka_app.py"
 description: "No description available."
 tags: ["module", "test_kafka_app"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_kafka_app
 

--- a/openwiki/modules/tests/controller/test_kafka_app_dos.md
+++ b/openwiki/modules/tests/controller/test_kafka_app_dos.md
@@ -6,10 +6,10 @@ title: "Module: test_kafka_app_dos"
 source_path: "tests/controller/test_kafka_app_dos.py"
 description: "No description available."
 tags: ["module", "test_kafka_app_dos"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_kafka_app_dos
 

--- a/openwiki/modules/tests/controller/test_kafka_app_leakage.md
+++ b/openwiki/modules/tests/controller/test_kafka_app_leakage.md
@@ -6,10 +6,10 @@ title: "Module: test_kafka_app_leakage"
 source_path: "tests/controller/test_kafka_app_leakage.py"
 description: "No description available."
 tags: ["module", "test_kafka_app_leakage"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_kafka_app_leakage
 

--- a/openwiki/modules/tests/controller/test_kafka_app_logging.md
+++ b/openwiki/modules/tests/controller/test_kafka_app_logging.md
@@ -6,10 +6,10 @@ title: "Module: test_kafka_app_logging"
 source_path: "tests/controller/test_kafka_app_logging.py"
 description: "No description available."
 tags: ["module", "test_kafka_app_logging"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_kafka_app_logging
 

--- a/openwiki/modules/tests/controller/test_kafka_app_security.md
+++ b/openwiki/modules/tests/controller/test_kafka_app_security.md
@@ -6,10 +6,10 @@ title: "Module: test_kafka_app_security"
 source_path: "tests/controller/test_kafka_app_security.py"
 description: "No description available."
 tags: ["module", "test_kafka_app_security"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_kafka_app_security
 

--- a/openwiki/modules/tests/controller/test_log_leakage.md
+++ b/openwiki/modules/tests/controller/test_log_leakage.md
@@ -6,10 +6,10 @@ title: "Module: test_log_leakage"
 source_path: "tests/controller/test_log_leakage.py"
 description: "No description available."
 tags: ["module", "test_log_leakage"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_log_leakage
 

--- a/openwiki/modules/tests/controller/test_middleware_config.md
+++ b/openwiki/modules/tests/controller/test_middleware_config.md
@@ -6,10 +6,10 @@ title: "Module: test_middleware_config"
 source_path: "tests/controller/test_middleware_config.py"
 description: "No description available."
 tags: ["module", "test_middleware_config"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_middleware_config
 

--- a/openwiki/modules/tests/controller/test_rate_limiter.md
+++ b/openwiki/modules/tests/controller/test_rate_limiter.md
@@ -6,10 +6,10 @@ title: "Module: test_rate_limiter"
 source_path: "tests/controller/test_rate_limiter.py"
 description: "No description available."
 tags: ["module", "test_rate_limiter"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_rate_limiter
 

--- a/openwiki/modules/tests/core/test_metrics.md
+++ b/openwiki/modules/tests/core/test_metrics.md
@@ -6,10 +6,10 @@ title: "Module: test_metrics"
 source_path: "tests/core/test_metrics.py"
 description: "No description available."
 tags: ["module", "test_metrics"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_metrics
 

--- a/openwiki/modules/tests/core/test_models.md
+++ b/openwiki/modules/tests/core/test_models.md
@@ -6,10 +6,10 @@ title: "Module: test_models"
 source_path: "tests/core/test_models.py"
 description: "No description available."
 tags: ["module", "test_models"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_models
 

--- a/openwiki/modules/tests/core/test_schemas.md
+++ b/openwiki/modules/tests/core/test_schemas.md
@@ -6,10 +6,10 @@ title: "Module: test_schemas"
 source_path: "tests/core/test_schemas.py"
 description: "No description available."
 tags: ["module", "test_schemas"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_schemas
 

--- a/openwiki/modules/tests/io/test_configs.md
+++ b/openwiki/modules/tests/io/test_configs.md
@@ -6,10 +6,10 @@ title: "Module: test_configs"
 source_path: "tests/io/test_configs.py"
 description: "No description available."
 tags: ["module", "test_configs"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_configs
 

--- a/openwiki/modules/tests/io/test_datasets.md
+++ b/openwiki/modules/tests/io/test_datasets.md
@@ -6,10 +6,10 @@ title: "Module: test_datasets"
 source_path: "tests/io/test_datasets.py"
 description: "No description available."
 tags: ["module", "test_datasets"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_datasets
 

--- a/openwiki/modules/tests/io/test_registries.md
+++ b/openwiki/modules/tests/io/test_registries.md
@@ -6,10 +6,10 @@ title: "Module: test_registries"
 source_path: "tests/io/test_registries.py"
 description: "No description available."
 tags: ["module", "test_registries"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_registries
 

--- a/openwiki/modules/tests/io/test_services.md
+++ b/openwiki/modules/tests/io/test_services.md
@@ -6,10 +6,10 @@ title: "Module: test_services"
 source_path: "tests/io/test_services.py"
 description: "No description available."
 tags: ["module", "test_services"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_services
 

--- a/openwiki/modules/tests/jobs/test_base.md
+++ b/openwiki/modules/tests/jobs/test_base.md
@@ -6,10 +6,10 @@ title: "Module: test_base"
 source_path: "tests/jobs/test_base.py"
 description: "No description available."
 tags: ["module", "test_base"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_base
 

--- a/openwiki/modules/tests/jobs/test_evaluations.md
+++ b/openwiki/modules/tests/jobs/test_evaluations.md
@@ -6,10 +6,10 @@ title: "Module: test_evaluations"
 source_path: "tests/jobs/test_evaluations.py"
 description: "No description available."
 tags: ["module", "test_evaluations"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_evaluations
 

--- a/openwiki/modules/tests/jobs/test_explanations.md
+++ b/openwiki/modules/tests/jobs/test_explanations.md
@@ -6,10 +6,10 @@ title: "Module: test_explanations"
 source_path: "tests/jobs/test_explanations.py"
 description: "No description available."
 tags: ["module", "test_explanations"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_explanations
 

--- a/openwiki/modules/tests/jobs/test_inference.md
+++ b/openwiki/modules/tests/jobs/test_inference.md
@@ -6,10 +6,10 @@ title: "Module: test_inference"
 source_path: "tests/jobs/test_inference.py"
 description: "No description available."
 tags: ["module", "test_inference"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_inference
 

--- a/openwiki/modules/tests/jobs/test_promotion.md
+++ b/openwiki/modules/tests/jobs/test_promotion.md
@@ -6,10 +6,10 @@ title: "Module: test_promotion"
 source_path: "tests/jobs/test_promotion.py"
 description: "No description available."
 tags: ["module", "test_promotion"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_promotion
 

--- a/openwiki/modules/tests/jobs/test_training.md
+++ b/openwiki/modules/tests/jobs/test_training.md
@@ -6,10 +6,10 @@ title: "Module: test_training"
 source_path: "tests/jobs/test_training.py"
 description: "No description available."
 tags: ["module", "test_training"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_training
 

--- a/openwiki/modules/tests/jobs/test_tuning.md
+++ b/openwiki/modules/tests/jobs/test_tuning.md
@@ -6,10 +6,10 @@ title: "Module: test_tuning"
 source_path: "tests/jobs/test_tuning.py"
 description: "No description available."
 tags: ["module", "test_tuning"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_tuning
 

--- a/openwiki/modules/tests/performance/benchmark_blocking.md
+++ b/openwiki/modules/tests/performance/benchmark_blocking.md
@@ -6,10 +6,10 @@ title: "Module: benchmark_blocking"
 source_path: "tests/performance/benchmark_blocking.py"
 description: "No description available."
 tags: ["module", "benchmark_blocking"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: benchmark_blocking
 

--- a/openwiki/modules/tests/test_scripts.md
+++ b/openwiki/modules/tests/test_scripts.md
@@ -6,10 +6,10 @@ title: "Module: test_scripts"
 source_path: "tests/test_scripts.py"
 description: "No description available."
 tags: ["module", "test_scripts"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_scripts
 

--- a/openwiki/modules/tests/utils/test_searchers.md
+++ b/openwiki/modules/tests/utils/test_searchers.md
@@ -6,10 +6,10 @@ title: "Module: test_searchers"
 source_path: "tests/utils/test_searchers.py"
 description: "No description available."
 tags: ["module", "test_searchers"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_searchers
 

--- a/openwiki/modules/tests/utils/test_signers.md
+++ b/openwiki/modules/tests/utils/test_signers.md
@@ -6,10 +6,10 @@ title: "Module: test_signers"
 source_path: "tests/utils/test_signers.py"
 description: "No description available."
 tags: ["module", "test_signers"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_signers
 

--- a/openwiki/modules/tests/utils/test_splitters.md
+++ b/openwiki/modules/tests/utils/test_splitters.md
@@ -6,10 +6,10 @@ title: "Module: test_splitters"
 source_path: "tests/utils/test_splitters.py"
 description: "No description available."
 tags: ["module", "test_splitters"]
-timestamp: "2026-08-16T06:27:37Z"
+timestamp: "2026-08-17T05:34:56Z"
 generated: "agent:ast-documentation-generator"
 verified: "true"
-last_verified_commit: "034727a"
+last_verified_commit: "73b4d7b"
 ---
 # Module Specification: test_splitters
 


### PR DESCRIPTION
- Fixed `generate_openwiki.py` to sort dictionary keys for `packages` and `edges` when building PlantUML diagrams.
- Ensures the final documentation is perfectly deterministic in `mode=full`.

---
*PR created automatically by Jules for task [12765147278231093275](https://jules.google.com/task/12765147278231093275) started by @lgcorzo*